### PR TITLE
Bugfix: Small spotify bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ tmp/
 **/piper.db
 jwk*.json
 **.bak
+.idea

--- a/db/db.go
+++ b/db/db.go
@@ -159,9 +159,9 @@ func (db *DB) GetUserByID(ID int64) (*models.User, error) {
 	user := &models.User{}
 
 	err := db.QueryRow(`
-	SELECT id, username, email, spotify_id, access_token, refresh_token, token_expiry, lastfm_username, created_at, updated_at
+	SELECT id, username, email, atproto_did, spotify_id, access_token, refresh_token, token_expiry, lastfm_username, created_at, updated_at
 	FROM users WHERE id = ?`, ID).Scan(
-		&user.ID, &user.Username, &user.Email, &user.SpotifyID,
+		&user.ID, &user.Username, &user.Email, &user.ATProtoDID, &user.SpotifyID,
 		&user.AccessToken, &user.RefreshToken, &user.TokenExpiry,
 		&user.LastFMUsername,
 		&user.CreatedAt, &user.UpdatedAt)

--- a/service/lastfm/lastfm.go
+++ b/service/lastfm/lastfm.go
@@ -316,35 +316,24 @@ func (l *LastFMService) processTracks(ctx context.Context, username string, trac
 		return nil
 	}
 
-	uts, err := strconv.ParseInt(lastNonNowPlaying.Date.UTS, 10, 64)
-	if err != nil {
-		log.Printf("error parsing timestamp '%s' for track %s - %s: %v",
-			lastNonNowPlaying.Date.UTS, lastNonNowPlaying.Artist.Text, lastNonNowPlaying.Name, err)
-	}
-	latestTrackTime := time.Unix(uts, 0)
+	latestTrackTime := lastNonNowPlaying.Date
 
 	// print both
 	fmt.Printf("latestTrackTime: %s\n", latestTrackTime)
 	fmt.Printf("lastKnownTimestamp: %s\n", lastKnownTimestamp)
 
-	if lastKnownTimestamp != nil && lastKnownTimestamp.Equal(latestTrackTime) {
+	if lastKnownTimestamp != nil && lastKnownTimestamp.Equal(latestTrackTime.Time) {
 		log.Printf("no new tracks to process for user %s.", username)
 		return nil
 	}
 
 	for _, track := range tracks {
-		if track.Date == nil || track.Date.UTS == "" {
+		if track.Date == nil {
 			log.Printf("skipping track without timestamp for %s: %s - %s", username, track.Artist.Text, track.Name)
 			continue
 		}
 
-		uts, err := strconv.ParseInt(track.Date.UTS, 10, 64)
-		if err != nil {
-			log.Printf("error parsing timestamp '%s' for track %s - %s: %v", track.Date.UTS, track.Artist.Text, track.Name, err)
-			continue
-		}
-		trackTime := time.Unix(uts, 0)
-
+		trackTime := track.Date.Time
 		// before or at last known
 		if lastKnownTimestamp != nil && (trackTime.Before(*lastKnownTimestamp) || trackTime.Equal(*lastKnownTimestamp)) {
 			if processedCount == 0 {

--- a/service/spotify/spotify.go
+++ b/service/spotify/spotify.go
@@ -507,16 +507,6 @@ func (s *SpotifyService) FetchCurrentTrack(userID int64) (*models.Track, error) 
 		return nil, fmt.Errorf("failed to unmarshal spotify response: %w", err)
 	}
 
-	body, ioErr := io.ReadAll(resp.Body)
-	if ioErr != nil {
-		return nil, ioErr
-	}
-
-	err = json.Unmarshal(body, &response)
-	if err != nil {
-		return nil, err
-	}
-
 	var artists []models.Artist
 	for _, artist := range response.Item.Artists {
 		artists = append(artists, models.Artist{

--- a/service/spotify/spotify.go
+++ b/service/spotify/spotify.go
@@ -526,7 +526,7 @@ func (s *SpotifyService) FetchCurrentTrack(userID int64) (*models.Track, error) 
 		ServiceBaseUrl: "open.spotify.com",
 		ISRC:           response.Item.ExternalIDs.ISRC,
 		HasStamped:     false,
-		Timestamp:      time.Now(),
+		Timestamp:      time.Now().UTC(),
 	}
 
 	return track, nil


### PR DESCRIPTION
Hey I was running through getting Piper to work and hit a couple of bugs before I could sync from currently listening Spotify to my PDS

- `aproto_did` mapping to `ATPRotoDID` was missing in the `GetUserByID` method
- Looks like there was a double check of the JSON that was throwing an error. Looks like it may already be checking for an error, then checked again and got "unexpected end of json". When that was removed, it worked. But this the first bit of Go I've ever written so not 100% sure if that's correct

But with those changes and the setup of the Spotify account, it syncs perfectly. 