### PR TITLE
Bugfix: Misc & Spotify improvements 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ air
 
 air should automatically build and run piper, and watch for changes on relevant files.
 
+#### Lexicon changes
+1. Copy the new or changed json schema files to the [lexicon folders](./lexicons)
+2. run `make go-lexicons`
+
+Go types should be updated and should have the changes to the schemas 
+
 #### docker
 
 TODO
+
+

--- a/api/teal/cbor_gen.go
+++ b/api/teal/cbor_gen.go
@@ -27,9 +27,17 @@ func (t *AlphaFeedPlay) MarshalCBOR(w io.Writer) error {
 	}
 
 	cw := cbg.NewCborWriter(w)
-	fieldCount := 14
+	fieldCount := 15
 
 	if t.ArtistMbIds == nil {
+		fieldCount--
+	}
+
+	if t.ArtistNames == nil {
+		fieldCount--
+	}
+
+	if t.Artists == nil {
 		fieldCount--
 	}
 
@@ -126,6 +134,35 @@ func (t *AlphaFeedPlay) MarshalCBOR(w io.Writer) error {
 	}
 	if _, err := cw.WriteString(string("fm.teal.alpha.feed.play")); err != nil {
 		return err
+	}
+
+	// t.Artists ([]*teal.AlphaFeedDefs_Artist) (slice)
+	if t.Artists != nil {
+
+		if len("artists") > 1000000 {
+			return xerrors.Errorf("Value in field \"artists\" was too long")
+		}
+
+		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("artists"))); err != nil {
+			return err
+		}
+		if _, err := cw.WriteString(string("artists")); err != nil {
+			return err
+		}
+
+		if len(t.Artists) > 8192 {
+			return xerrors.Errorf("Slice value in field t.Artists was too long")
+		}
+
+		if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Artists))); err != nil {
+			return err
+		}
+		for _, v := range t.Artists {
+			if err := v.MarshalCBOR(cw); err != nil {
+				return err
+			}
+
+		}
 	}
 
 	// t.Duration (int64) (int64)
@@ -316,36 +353,39 @@ func (t *AlphaFeedPlay) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.ArtistNames ([]string) (slice)
-	if len("artistNames") > 1000000 {
-		return xerrors.Errorf("Value in field \"artistNames\" was too long")
-	}
+	if t.ArtistNames != nil {
 
-	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("artistNames"))); err != nil {
-		return err
-	}
-	if _, err := cw.WriteString(string("artistNames")); err != nil {
-		return err
-	}
-
-	if len(t.ArtistNames) > 8192 {
-		return xerrors.Errorf("Slice value in field t.ArtistNames was too long")
-	}
-
-	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.ArtistNames))); err != nil {
-		return err
-	}
-	for _, v := range t.ArtistNames {
-		if len(v) > 1000000 {
-			return xerrors.Errorf("Value in field v was too long")
+		if len("artistNames") > 1000000 {
+			return xerrors.Errorf("Value in field \"artistNames\" was too long")
 		}
 
-		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(v))); err != nil {
+		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("artistNames"))); err != nil {
 			return err
 		}
-		if _, err := cw.WriteString(string(v)); err != nil {
+		if _, err := cw.WriteString(string("artistNames")); err != nil {
 			return err
 		}
 
+		if len(t.ArtistNames) > 8192 {
+			return xerrors.Errorf("Slice value in field t.ArtistNames was too long")
+		}
+
+		if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.ArtistNames))); err != nil {
+			return err
+		}
+		for _, v := range t.ArtistNames {
+			if len(v) > 1000000 {
+				return xerrors.Errorf("Value in field v was too long")
+			}
+
+			if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(v))); err != nil {
+				return err
+			}
+			if _, err := cw.WriteString(string(v)); err != nil {
+				return err
+			}
+
+		}
 	}
 
 	// t.ReleaseMbId (string) (string)
@@ -582,6 +622,55 @@ func (t *AlphaFeedPlay) UnmarshalCBOR(r io.Reader) (err error) {
 				}
 
 				t.LexiconTypeID = string(sval)
+			}
+			// t.Artists ([]*teal.AlphaFeedDefs_Artist) (slice)
+		case "artists":
+
+			maj, extra, err = cr.ReadHeader()
+			if err != nil {
+				return err
+			}
+
+			if extra > 8192 {
+				return fmt.Errorf("t.Artists: array too large (%d)", extra)
+			}
+
+			if maj != cbg.MajArray {
+				return fmt.Errorf("expected cbor array")
+			}
+
+			if extra > 0 {
+				t.Artists = make([]*AlphaFeedDefs_Artist, extra)
+			}
+
+			for i := 0; i < int(extra); i++ {
+				{
+					var maj byte
+					var extra uint64
+					var err error
+					_ = maj
+					_ = extra
+					_ = err
+
+					{
+
+						b, err := cr.ReadByte()
+						if err != nil {
+							return err
+						}
+						if b != cbg.CborNull[0] {
+							if err := cr.UnreadByte(); err != nil {
+								return err
+							}
+							t.Artists[i] = new(AlphaFeedDefs_Artist)
+							if err := t.Artists[i].UnmarshalCBOR(cr); err != nil {
+								return xerrors.Errorf("unmarshaling t.Artists[i] pointer: %w", err)
+							}
+						}
+
+					}
+
+				}
 			}
 			// t.Duration (int64) (int64)
 		case "duration":
@@ -1733,11 +1822,7 @@ func (t *AlphaFeedDefs_PlayView) MarshalCBOR(w io.Writer) error {
 	}
 
 	cw := cbg.NewCborWriter(w)
-	fieldCount := 13
-
-	if t.ArtistMbIds == nil {
-		fieldCount--
-	}
+	fieldCount := 12
 
 	if t.Duration == nil {
 		fieldCount--
@@ -1813,6 +1898,32 @@ func (t *AlphaFeedDefs_PlayView) MarshalCBOR(w io.Writer) error {
 				return err
 			}
 		}
+	}
+
+	// t.Artists ([]*teal.AlphaFeedDefs_Artist) (slice)
+	if len("artists") > 1000000 {
+		return xerrors.Errorf("Value in field \"artists\" was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("artists"))); err != nil {
+		return err
+	}
+	if _, err := cw.WriteString(string("artists")); err != nil {
+		return err
+	}
+
+	if len(t.Artists) > 8192 {
+		return xerrors.Errorf("Slice value in field t.Artists was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Artists))); err != nil {
+		return err
+	}
+	for _, v := range t.Artists {
+		if err := v.MarshalCBOR(cw); err != nil {
+			return err
+		}
+
 	}
 
 	// t.Duration (int64) (int64)
@@ -1964,75 +2075,6 @@ func (t *AlphaFeedDefs_PlayView) MarshalCBOR(w io.Writer) error {
 				return err
 			}
 		}
-	}
-
-	// t.ArtistMbIds ([]string) (slice)
-	if t.ArtistMbIds != nil {
-
-		if len("artistMbIds") > 1000000 {
-			return xerrors.Errorf("Value in field \"artistMbIds\" was too long")
-		}
-
-		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("artistMbIds"))); err != nil {
-			return err
-		}
-		if _, err := cw.WriteString(string("artistMbIds")); err != nil {
-			return err
-		}
-
-		if len(t.ArtistMbIds) > 8192 {
-			return xerrors.Errorf("Slice value in field t.ArtistMbIds was too long")
-		}
-
-		if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.ArtistMbIds))); err != nil {
-			return err
-		}
-		for _, v := range t.ArtistMbIds {
-			if len(v) > 1000000 {
-				return xerrors.Errorf("Value in field v was too long")
-			}
-
-			if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(v))); err != nil {
-				return err
-			}
-			if _, err := cw.WriteString(string(v)); err != nil {
-				return err
-			}
-
-		}
-	}
-
-	// t.ArtistNames ([]string) (slice)
-	if len("artistNames") > 1000000 {
-		return xerrors.Errorf("Value in field \"artistNames\" was too long")
-	}
-
-	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("artistNames"))); err != nil {
-		return err
-	}
-	if _, err := cw.WriteString(string("artistNames")); err != nil {
-		return err
-	}
-
-	if len(t.ArtistNames) > 8192 {
-		return xerrors.Errorf("Slice value in field t.ArtistNames was too long")
-	}
-
-	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.ArtistNames))); err != nil {
-		return err
-	}
-	for _, v := range t.ArtistNames {
-		if len(v) > 1000000 {
-			return xerrors.Errorf("Value in field v was too long")
-		}
-
-		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(v))); err != nil {
-			return err
-		}
-		if _, err := cw.WriteString(string(v)); err != nil {
-			return err
-		}
-
 	}
 
 	// t.ReleaseMbId (string) (string)
@@ -2259,6 +2301,55 @@ func (t *AlphaFeedDefs_PlayView) UnmarshalCBOR(r io.Reader) (err error) {
 					t.Isrc = (*string)(&sval)
 				}
 			}
+			// t.Artists ([]*teal.AlphaFeedDefs_Artist) (slice)
+		case "artists":
+
+			maj, extra, err = cr.ReadHeader()
+			if err != nil {
+				return err
+			}
+
+			if extra > 8192 {
+				return fmt.Errorf("t.Artists: array too large (%d)", extra)
+			}
+
+			if maj != cbg.MajArray {
+				return fmt.Errorf("expected cbor array")
+			}
+
+			if extra > 0 {
+				t.Artists = make([]*AlphaFeedDefs_Artist, extra)
+			}
+
+			for i := 0; i < int(extra); i++ {
+				{
+					var maj byte
+					var extra uint64
+					var err error
+					_ = maj
+					_ = extra
+					_ = err
+
+					{
+
+						b, err := cr.ReadByte()
+						if err != nil {
+							return err
+						}
+						if b != cbg.CborNull[0] {
+							if err := cr.UnreadByte(); err != nil {
+								return err
+							}
+							t.Artists[i] = new(AlphaFeedDefs_Artist)
+							if err := t.Artists[i].UnmarshalCBOR(cr); err != nil {
+								return xerrors.Errorf("unmarshaling t.Artists[i] pointer: %w", err)
+							}
+						}
+
+					}
+
+				}
+			}
 			// t.Duration (int64) (int64)
 		case "duration":
 			{
@@ -2369,86 +2460,6 @@ func (t *AlphaFeedDefs_PlayView) UnmarshalCBOR(r io.Reader) (err error) {
 					t.PlayedTime = (*string)(&sval)
 				}
 			}
-			// t.ArtistMbIds ([]string) (slice)
-		case "artistMbIds":
-
-			maj, extra, err = cr.ReadHeader()
-			if err != nil {
-				return err
-			}
-
-			if extra > 8192 {
-				return fmt.Errorf("t.ArtistMbIds: array too large (%d)", extra)
-			}
-
-			if maj != cbg.MajArray {
-				return fmt.Errorf("expected cbor array")
-			}
-
-			if extra > 0 {
-				t.ArtistMbIds = make([]string, extra)
-			}
-
-			for i := 0; i < int(extra); i++ {
-				{
-					var maj byte
-					var extra uint64
-					var err error
-					_ = maj
-					_ = extra
-					_ = err
-
-					{
-						sval, err := cbg.ReadStringWithMax(cr, 1000000)
-						if err != nil {
-							return err
-						}
-
-						t.ArtistMbIds[i] = string(sval)
-					}
-
-				}
-			}
-			// t.ArtistNames ([]string) (slice)
-		case "artistNames":
-
-			maj, extra, err = cr.ReadHeader()
-			if err != nil {
-				return err
-			}
-
-			if extra > 8192 {
-				return fmt.Errorf("t.ArtistNames: array too large (%d)", extra)
-			}
-
-			if maj != cbg.MajArray {
-				return fmt.Errorf("expected cbor array")
-			}
-
-			if extra > 0 {
-				t.ArtistNames = make([]string, extra)
-			}
-
-			for i := 0; i < int(extra); i++ {
-				{
-					var maj byte
-					var extra uint64
-					var err error
-					_ = maj
-					_ = extra
-					_ = err
-
-					{
-						sval, err := cbg.ReadStringWithMax(cr, 1000000)
-						if err != nil {
-							return err
-						}
-
-						t.ArtistNames[i] = string(sval)
-					}
-
-				}
-			}
 			// t.ReleaseMbId (string) (string)
 		case "releaseMbId":
 
@@ -2553,6 +2564,164 @@ func (t *AlphaFeedDefs_PlayView) UnmarshalCBOR(r io.Reader) (err error) {
 
 					t.MusicServiceBaseDomain = (*string)(&sval)
 				}
+			}
+
+		default:
+			// Field doesn't exist on this type, so ignore it
+			if err := cbg.ScanForLinks(r, func(cid.Cid) {}); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+func (t *AlphaFeedDefs_Artist) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+
+	cw := cbg.NewCborWriter(w)
+	fieldCount := 2
+
+	if t.ArtistMbId == nil {
+		fieldCount--
+	}
+
+	if _, err := cw.Write(cbg.CborEncodeMajorType(cbg.MajMap, uint64(fieldCount))); err != nil {
+		return err
+	}
+
+	// t.ArtistMbId (string) (string)
+	if t.ArtistMbId != nil {
+
+		if len("artistMbId") > 1000000 {
+			return xerrors.Errorf("Value in field \"artistMbId\" was too long")
+		}
+
+		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("artistMbId"))); err != nil {
+			return err
+		}
+		if _, err := cw.WriteString(string("artistMbId")); err != nil {
+			return err
+		}
+
+		if t.ArtistMbId == nil {
+			if _, err := cw.Write(cbg.CborNull); err != nil {
+				return err
+			}
+		} else {
+			if len(*t.ArtistMbId) > 1000000 {
+				return xerrors.Errorf("Value in field t.ArtistMbId was too long")
+			}
+
+			if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(*t.ArtistMbId))); err != nil {
+				return err
+			}
+			if _, err := cw.WriteString(string(*t.ArtistMbId)); err != nil {
+				return err
+			}
+		}
+	}
+
+	// t.ArtistName (string) (string)
+	if len("artistName") > 1000000 {
+		return xerrors.Errorf("Value in field \"artistName\" was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("artistName"))); err != nil {
+		return err
+	}
+	if _, err := cw.WriteString(string("artistName")); err != nil {
+		return err
+	}
+
+	if len(t.ArtistName) > 1000000 {
+		return xerrors.Errorf("Value in field t.ArtistName was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.ArtistName))); err != nil {
+		return err
+	}
+	if _, err := cw.WriteString(string(t.ArtistName)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *AlphaFeedDefs_Artist) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = AlphaFeedDefs_Artist{}
+
+	cr := cbg.NewCborReader(r)
+
+	maj, extra, err := cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
+	}()
+
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("AlphaFeedDefs_Artist: map struct too large (%d)", extra)
+	}
+
+	n := extra
+
+	nameBuf := make([]byte, 10)
+	for i := uint64(0); i < n; i++ {
+		nameLen, ok, err := cbg.ReadFullStringIntoBuf(cr, nameBuf, 1000000)
+		if err != nil {
+			return err
+		}
+
+		if !ok {
+			// Field doesn't exist on this type, so ignore it
+			if err := cbg.ScanForLinks(cr, func(cid.Cid) {}); err != nil {
+				return err
+			}
+			continue
+		}
+
+		switch string(nameBuf[:nameLen]) {
+		// t.ArtistMbId (string) (string)
+		case "artistMbId":
+
+			{
+				b, err := cr.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := cr.UnreadByte(); err != nil {
+						return err
+					}
+
+					sval, err := cbg.ReadStringWithMax(cr, 1000000)
+					if err != nil {
+						return err
+					}
+
+					t.ArtistMbId = (*string)(&sval)
+				}
+			}
+			// t.ArtistName (string) (string)
+		case "artistName":
+
+			{
+				sval, err := cbg.ReadStringWithMax(cr, 1000000)
+				if err != nil {
+					return err
+				}
+
+				t.ArtistName = string(sval)
 			}
 
 		default:

--- a/api/teal/feeddefs.go
+++ b/api/teal/feeddefs.go
@@ -4,12 +4,18 @@ package teal
 
 // schema: fm.teal.alpha.feed.defs
 
+// AlphaFeedDefs_Artist is a "artist" in the fm.teal.alpha.feed.defs schema.
+type AlphaFeedDefs_Artist struct {
+	// artistMbId: The Musicbrainz ID of the artist
+	ArtistMbId *string `json:"artistMbId,omitempty" cborgen:"artistMbId,omitempty"`
+	// artistName: The name of the artist
+	ArtistName string `json:"artistName" cborgen:"artistName"`
+}
+
 // AlphaFeedDefs_PlayView is a "playView" in the fm.teal.alpha.feed.defs schema.
 type AlphaFeedDefs_PlayView struct {
-	// artistMbIds: Array of Musicbrainz artist IDs
-	ArtistMbIds []string `json:"artistMbIds,omitempty" cborgen:"artistMbIds,omitempty"`
-	// artistNames: Array of artist names in order of original appearance.
-	ArtistNames []string `json:"artistNames" cborgen:"artistNames"`
+	// artists: Array of artists in order of original appearance.
+	Artists []*AlphaFeedDefs_Artist `json:"artists" cborgen:"artists"`
 	// duration: The length of the track in seconds
 	Duration *int64 `json:"duration,omitempty" cborgen:"duration,omitempty"`
 	// isrc: The ISRC code associated with the recording

--- a/api/teal/feedplay.go
+++ b/api/teal/feedplay.go
@@ -14,10 +14,12 @@ func init() {
 // RECORDTYPE: AlphaFeedPlay
 type AlphaFeedPlay struct {
 	LexiconTypeID string `json:"$type,const=fm.teal.alpha.feed.play" cborgen:"$type,const=fm.teal.alpha.feed.play"`
-	// artistMbIds: Array of Musicbrainz artist IDs
+	// artistMbIds: Array of Musicbrainz artist IDs. Prefer using 'artists'.
 	ArtistMbIds []string `json:"artistMbIds,omitempty" cborgen:"artistMbIds,omitempty"`
-	// artistNames: Array of artist names in order of original appearance.
-	ArtistNames []string `json:"artistNames" cborgen:"artistNames"`
+	// artistNames: Array of artist names in order of original appearance. Prefer using 'artists'.
+	ArtistNames []string `json:"artistNames,omitempty" cborgen:"artistNames,omitempty"`
+	// artists: Array of artists in order of original appearance.
+	Artists []*AlphaFeedDefs_Artist `json:"artists,omitempty" cborgen:"artists,omitempty"`
 	// duration: The length of the track in seconds
 	Duration *int64 `json:"duration,omitempty" cborgen:"duration,omitempty"`
 	// isrc: The ISRC code associated with the recording

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/teal-fm/piper/service/lastfm"
 	"log"
 	"net/http"
 	"os"
@@ -14,7 +15,6 @@ import (
 	"github.com/teal-fm/piper/oauth"
 	"github.com/teal-fm/piper/oauth/atproto"
 	apikeyService "github.com/teal-fm/piper/service/apikey"
-	"github.com/teal-fm/piper/service/lastfm"
 	"github.com/teal-fm/piper/service/musicbrainz"
 	"github.com/teal-fm/piper/service/spotify"
 	"github.com/teal-fm/piper/session"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -108,9 +108,9 @@ func main() {
 		lastfmInterval = 30 * time.Second
 	}
 
-	if err := spotifyService.LoadAllUsers(); err != nil {
-		log.Printf("Warning: Failed to preload Spotify users: %v", err)
-	}
+	//if err := spotifyService.LoadAllUsers(); err != nil {
+	//	log.Printf("Warning: Failed to preload Spotify users: %v", err)
+	//}
 	go spotifyService.StartListeningTracker(trackerInterval)
 
 	go lastfmService.StartListeningTracker(lastfmInterval)

--- a/db/apikey/apikey.go
+++ b/db/apikey/apikey.go
@@ -64,7 +64,7 @@ func (am *ApiKeyManager) CreateApiKey(userID int64, name string, validityDays in
 	}
 	apiKeyID := base64.URLEncoding.EncodeToString(b)
 
-	now := time.Now()
+	now := time.Now().UTC()
 	expiresAt := now.AddDate(0, 0, validityDays) // Default to validityDays days validity
 
 	apiKey := &ApiKey{
@@ -100,7 +100,7 @@ func (am *ApiKeyManager) GetApiKey(apiKeyID string) (*ApiKey, bool) {
 
 	if exists {
 		// Check if API key is expired
-		if time.Now().After(apiKey.ExpiresAt) {
+		if time.Now().UTC().After(apiKey.ExpiresAt) {
 			am.DeleteApiKey(apiKeyID)
 			return nil, false
 		}
@@ -118,7 +118,7 @@ func (am *ApiKeyManager) GetApiKey(apiKeyID string) (*ApiKey, bool) {
 		return nil, false
 	}
 
-	if time.Now().After(apiKey.ExpiresAt) {
+	if time.Now().UTC().After(apiKey.ExpiresAt) {
 		am.DeleteApiKey(apiKeyID)
 		return nil, false
 	}

--- a/db/atproto.go
+++ b/db/atproto.go
@@ -246,7 +246,8 @@ func (db *DB) GetAtprotoSession(did string, ctx context.Context, oauthClient oau
 }
 
 func AtpSessionToAuthArgs(sess *models.ATprotoAuthSession) *oauth.XrpcAuthedRequestArgs {
-	fmt.Printf("DID: %s\nPDS URL: %s\nISS: %s\nAccess Token: %s\nNonce: %s\nPrivate JWK: %s\n", sess.DID, sess.PDSUrl, sess.AuthServerIssuer, sess.AccessToken, sess.DpopPdsNonce, sess.DpopPrivateJWK)
+	//Commenting out so jwts and tokens are not in logs
+	//fmt.Printf("DID: %s\nPDS URL: %s\nISS: %s\nAccess Token: %s\nNonce: %s\nPrivate JWK: %s\n", sess.DID, sess.PDSUrl, sess.AuthServerIssuer, sess.AccessToken, sess.DpopPdsNonce, sess.DpopPrivateJWK)
 	return &oauth.XrpcAuthedRequestArgs{
 		Did:            sess.DID,
 		PdsUrl:         sess.PDSUrl,

--- a/db/atproto.go
+++ b/db/atproto.go
@@ -172,10 +172,20 @@ func (db *DB) GetAtprotoSession(did string, ctx context.Context, oauthClient oau
 	var authserverIss string
 	var jwkBytes string
 
-	err := db.QueryRow(`
-		SELECT id, atproto_did, atproto_pds_url, atproto_authserver_issuer, atproto_access_token, atproto_refresh_token, atproto_pds_nonce, atproto_authserver_nonce, atproto_dpop_private_jwk, atproto_token_expiry
+	err := db.QueryRow(
+		`
+		SELECT id, 
+		       atproto_did,
+		       atproto_pds_url,
+		       atproto_authserver_issuer,
+		       atproto_access_token,
+		       atproto_refresh_token,
+		       atproto_pds_nonce,
+		       atproto_authserver_nonce,
+		       atproto_dpop_private_jwk,
+		       atproto_token_expiry
 		FROM users
-		WHERE atproto_did = ? OR id`,
+		WHERE atproto_did = ?`,
 		did,
 	).Scan(
 		&oauthSession.ID,

--- a/db/atproto.go
+++ b/db/atproto.go
@@ -110,7 +110,7 @@ func (db *DB) FindOrCreateUserByDID(did string) (*models.User, error) {
 
 // create or update the current user's ATproto session data.
 func (db *DB) SaveATprotoSession(tokenResp *oauth.TokenResponse, authserverIss string, dpopPrivateJWK jwk.Key, pdsUrl string) error {
-	fmt.Printf("Saving session with PDS url %s", pdsUrl)
+	db.logger.Printf("Saving session with PDS url %s", pdsUrl)
 	expiryTime := time.Now().UTC().Add(time.Second * time.Duration(tokenResp.ExpiresIn))
 	now := time.Now().UTC()
 
@@ -213,7 +213,7 @@ func (db *DB) GetAtprotoSession(did string, ctx context.Context, oauthClient oau
 	}
 
 	// printout the session details
-	fmt.Printf("Getting session details for the did: %+v\n", oauthSession.DID)
+	db.logger.Printf("Getting session details for the did: %+v\n", oauthSession.DID)
 
 	// if token is expired, refresh it
 	if time.Now().UTC().After(oauthSession.TokenExpiry) {

--- a/db/db.go
+++ b/db/db.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"time"
@@ -14,6 +15,7 @@ import (
 
 type DB struct {
 	*sql.DB
+	logger *log.Logger
 }
 
 func New(dbPath string) (*DB, error) {
@@ -31,8 +33,9 @@ func New(dbPath string) (*DB, error) {
 	if err = db.Ping(); err != nil {
 		return nil, err
 	}
+	logger := log.New(os.Stdout, "db: ", log.LstdFlags|log.Lmsgprefix)
 
-	return &DB{db}, nil
+	return &DB{db, logger}, nil
 }
 
 func (db *DB) Initialize() error {

--- a/db/db.go
+++ b/db/db.go
@@ -120,7 +120,7 @@ func (db *DB) Initialize() error {
 
 // create user without spotify id
 func (db *DB) CreateUser(user *models.User) (int64, error) {
-	now := time.Now()
+	now := time.Now().UTC()
 
 	result, err := db.Exec(`
 	INSERT INTO users (username, email, created_at, updated_at)
@@ -136,7 +136,7 @@ func (db *DB) CreateUser(user *models.User) (int64, error) {
 
 // add spotify session to user, returning the updated user
 func (db *DB) AddSpotifySession(userID int64, username, email, spotifyId, accessToken, refreshToken string, tokenExpiry time.Time) (*models.User, error) {
-	now := time.Now()
+	now := time.Now().UTC()
 
 	_, err := db.Exec(`
 	UPDATE users SET username = ?, email = ?, spotify_id = ?, access_token = ?, refresh_token = ?, token_expiry = ?, created_at = ?, updated_at = ?
@@ -200,7 +200,7 @@ func (db *DB) GetUserBySpotifyID(spotifyID string) (*models.User, error) {
 }
 
 func (db *DB) UpdateUserToken(userID int64, accessToken, refreshToken string, expiry time.Time) error {
-	now := time.Now()
+	now := time.Now().UTC()
 
 	_, err := db.Exec(`
 	UPDATE users
@@ -326,7 +326,7 @@ func (db *DB) GetUsersWithExpiredTokens() ([]*models.User, error) {
     SELECT id, username, email, spotify_id, access_token, refresh_token, token_expiry, created_at, updated_at
     FROM users
     WHERE refresh_token IS NOT NULL AND token_expiry < ?
-    ORDER BY id`, time.Now())
+    ORDER BY id`, time.Now().UTC())
 
 	if err != nil {
 		return nil, err
@@ -355,7 +355,7 @@ func (db *DB) GetAllActiveUsers() ([]*models.User, error) {
     SELECT id, username, email, spotify_id, access_token, refresh_token, token_expiry, created_at, updated_at
     FROM users
     WHERE access_token IS NOT NULL AND token_expiry > ?
-    ORDER BY id`, time.Now())
+    ORDER BY id`, time.Now().UTC())
 
 	if err != nil {
 		return nil, err

--- a/lexicons/teal/feed/defs.json
+++ b/lexicons/teal/feed/defs.json
@@ -5,7 +5,7 @@
   "defs": {
     "playView": {
       "type": "object",
-      "required": ["trackName", "artistNames"],
+      "required": ["trackName", "artists"],
       "properties": {
         "trackName": {
           "type": "string",
@@ -26,22 +26,13 @@
           "type": "integer",
           "description": "The length of the track in seconds"
         },
-        "artistNames": {
+        "artists": {
           "type": "array",
           "items": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 256,
-            "maxGraphemes": 2560
+            "type": "ref",
+            "ref": "#artist"
           },
-          "description": "Array of artist names in order of original appearance."
-        },
-        "artistMbIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Array of Musicbrainz artist IDs"
+          "description": "Array of artists in order of original appearance."
         },
         "releaseName": {
           "type": "string",
@@ -75,6 +66,23 @@
           "type": "string",
           "format": "datetime",
           "description": "The unix timestamp of when the track was played"
+        }
+      }
+    },
+    "artist": {
+      "type": "object",
+      "required": ["artistName"],
+      "properties": {
+        "artistName": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256,
+          "maxGraphemes": 2560,
+          "description": "The name of the artist"
+        },
+        "artistMbId": {
+          "type": "string",
+          "description": "The Musicbrainz ID of the artist"
         }
       }
     }

--- a/lexicons/teal/feed/play.json
+++ b/lexicons/teal/feed/play.json
@@ -8,7 +8,7 @@
       "key": "tid",
       "record": {
         "type": "object",
-        "required": ["trackName", "artistNames"],
+        "required": ["trackName"],
         "properties": {
           "trackName": {
             "type": "string",
@@ -38,14 +38,22 @@
               "maxLength": 256,
               "maxGraphemes": 2560
             },
-            "description": "Array of artist names in order of original appearance."
+            "description": "Array of artist names in order of original appearance. Prefer using 'artists'."
           },
           "artistMbIds": {
             "type": "array",
             "items": {
               "type": "string"
             },
-            "description": "Array of Musicbrainz artist IDs"
+            "description": "Array of Musicbrainz artist IDs. Prefer using 'artists'."
+          },
+          "artists": {
+            "type": "array",
+            "items": {
+              "type": "ref",
+              "ref": "fm.teal.alpha.feed.defs#artist"
+            },
+            "description": "Array of artists in order of original appearance."
           },
           "releaseName": {
             "type": "string",

--- a/models/track.go
+++ b/models/track.go
@@ -7,11 +7,11 @@ type Track struct {
 	PlayID int64  `json:"playId"`
 	Name   string `json:"name"`
 	// analogous to "track"
-	RecordingMBID string   `json:"trackMBID"`
+	RecordingMBID *string  `json:"trackMBID,omitempty"`
 	Artist        []Artist `json:"artist"`
 	Album         string   `json:"album"`
 	// analogous to "album"
-	ReleaseMBID    string    `json:"releaseMBID"`
+	ReleaseMBID    *string   `json:"releaseMBID,omitempty"`
 	URL            string    `json:"url"`
 	Timestamp      time.Time `json:"timestamp"`
 	DurationMs     int64     `json:"durationMs"`
@@ -22,7 +22,7 @@ type Track struct {
 }
 
 type Artist struct {
-	Name string `json:"name"`
-	ID   string `json:"id"`
-	MBID string `json:"mbid"`
+	Name string  `json:"name"`
+	ID   string  `json:"id"`
+	MBID *string `json:"mbid,omitempty"`
 }

--- a/oauth/oauth2.go
+++ b/oauth/oauth2.go
@@ -123,9 +123,8 @@ func (o *OAuth2Service) HandleCallback(w http.ResponseWriter, r *http.Request) (
 	}
 
 	userId, hasSession := session.GetUserID(r.Context())
-
 	// store token and get uid
-	userID, err := o.tokenReceiver.SetAccessToken(token.AccessToken, userId, hasSession)
+	userID, err := o.tokenReceiver.SetAccessToken(token.AccessToken, token.RefreshToken, userId, hasSession)
 	if err != nil {
 		log.Printf("OAuth2 Callback Info: TokenReceiver did not return a valid user ID for token: %s...", token.AccessToken[:min(10, len(token.AccessToken))])
 	}

--- a/oauth/service.go
+++ b/oauth/service.go
@@ -16,5 +16,5 @@ type AuthService interface {
 type TokenReceiver interface {
 	// stores the access token in the db
 	// if there is a session, will associate the token with the session
-	SetAccessToken(token string, currentId int64, hasSession bool) (int64, error)
+	SetAccessToken(token string, refreshToken string, currentId int64, hasSession bool) (int64, error)
 }

--- a/service/apikey/apikey.go
+++ b/service/apikey/apikey.go
@@ -79,7 +79,7 @@ func (s *Service) HandleAPIKeyManagement(w http.ResponseWriter, r *http.Request)
 			}
 			keyName := reqBody.Name
 			if keyName == "" {
-				keyName = fmt.Sprintf("API Key (via API) - %s", time.Now().Format(time.RFC3339))
+				keyName = fmt.Sprintf("API Key (via API) - %s", time.Now().UTC().Format(time.RFC3339))
 			}
 			validityDays := 30 // Default, could be made configurable via request body
 
@@ -133,7 +133,7 @@ func (s *Service) HandleAPIKeyManagement(w http.ResponseWriter, r *http.Request)
 
 		keyName := r.FormValue("name")
 		if keyName == "" {
-			keyName = fmt.Sprintf("API Key - %s", time.Now().Format(time.RFC3339))
+			keyName = fmt.Sprintf("API Key - %s", time.Now().UTC().Format(time.RFC3339))
 		}
 		validityDays := 1024
 

--- a/service/lastfm/lastfm.go
+++ b/service/lastfm/lastfm.go
@@ -407,7 +407,7 @@ func (l *LastFMService) SubmitTrackToPDS(did string, track *models.Track, ctx co
 	}
 
 	// printout the session details
-	fmt.Printf("Session details: %+v\n", sess)
+	fmt.Printf("Submitting track for the did: %+v\n", sess.DID)
 
 	// horrible no good very bad for now
 	artistArr := []string{}

--- a/service/lastfm/lastfm.go
+++ b/service/lastfm/lastfm.go
@@ -418,7 +418,7 @@ func (l *LastFMService) SubmitTrackToPDS(did string, track *models.Track, ctx co
 	for _, a := range track.Artist {
 		artist := &teal.AlphaFeedDefs_Artist{
 			ArtistName: a.Name,
-			ArtistMbId: &a.MBID,
+			ArtistMbId: a.MBID,
 		}
 		artists = append(artists, artist)
 	}
@@ -444,10 +444,10 @@ func (l *LastFMService) SubmitTrackToPDS(did string, track *models.Track, ctx co
 		// should be unix timestamp
 		PlayedTime:            &playedTimeStr, // Pointer required
 		Artists:               artists,
-		ReleaseMbId:           &track.ReleaseMBID,   // Pointer required
-		ReleaseName:           &track.Album,         // Pointer required
-		RecordingMbId:         &track.RecordingMBID, // Pointer required
-		SubmissionClientAgent: &submissionAgent,     // Pointer required
+		ReleaseMbId:           track.ReleaseMBID,   // Pointer required
+		ReleaseName:           &track.Album,        // Pointer required
+		RecordingMbId:         track.RecordingMBID, // Pointer required
+		SubmissionClientAgent: &submissionAgent,    // Pointer required
 	}
 
 	input := atproto.RepoCreateRecord_Input{

--- a/service/musicbrainz/musicbrainz.go
+++ b/service/musicbrainz/musicbrainz.go
@@ -296,7 +296,7 @@ func HydrateTrack(mb *MusicBrainzService, track models.Track) (*models.Track, er
 		artists[i] = models.Artist{
 			Name: a.Name,
 			ID:   a.Artist.ID,
-			MBID: a.Artist.ID,
+			MBID: &a.Artist.ID,
 		}
 	}
 
@@ -306,9 +306,9 @@ func HydrateTrack(mb *MusicBrainzService, track models.Track) (*models.Track, er
 		Name:           track.Name,
 		URL:            track.URL,
 		ServiceBaseUrl: track.ServiceBaseUrl,
-		RecordingMBID:  firstResult.ID,
+		RecordingMBID:  &firstResult.ID,
 		Album:          firstResultAlbum.Title,
-		ReleaseMBID:    firstResultAlbum.ID,
+		ReleaseMBID:    &firstResultAlbum.ID,
 		ISRC:           bestISRC,
 		Timestamp:      track.Timestamp,
 		ProgressMs:     track.ProgressMs,

--- a/service/musicbrainz/musicbrainz.go
+++ b/service/musicbrainz/musicbrainz.go
@@ -119,7 +119,7 @@ func (s *MusicBrainzService) SearchMusicBrainz(ctx context.Context, params Searc
 	params.Artist, _ = s.cleaner.CleanArtist(params.Artist)
 
 	cacheKey := generateCacheKey(params)
-	now := time.Now()
+	now := time.Now().UTC()
 
 	// --- Check Cache (Read Lock) ---
 	s.cacheMutex.RLock()
@@ -188,7 +188,7 @@ func (s *MusicBrainzService) SearchMusicBrainz(ctx context.Context, params Searc
 	s.cacheMutex.Lock()
 	s.searchCache[cacheKey] = cacheEntry{
 		recordings: result.Recordings,
-		expiresAt:  time.Now().Add(s.cacheTTL),
+		expiresAt:  time.Now().UTC().Add(s.cacheTTL),
 	}
 	s.cacheMutex.Unlock()
 	log.Printf("Cached MusicBrainz search result for key=%s, TTL=%s", cacheKey, s.cacheTTL)

--- a/service/spotify/spotify.go
+++ b/service/spotify/spotify.go
@@ -117,8 +117,8 @@ func (s *SpotifyService) SubmitTrackToPDS(did string, track *models.Track, ctx c
 	return nil
 }
 
-func (s *SpotifyService) SetAccessToken(token string, userId int64, hasSession bool) (int64, error) {
-	userID, err := s.identifyAndStoreUser(token, userId, hasSession)
+func (s *SpotifyService) SetAccessToken(token string, refreshToken string, userId int64, hasSession bool) (int64, error) {
+	userID, err := s.identifyAndStoreUser(token, refreshToken, userId, hasSession)
 	if err != nil {
 		log.Printf("Error identifying and storing user: %v", err)
 		return 0, err
@@ -126,7 +126,7 @@ func (s *SpotifyService) SetAccessToken(token string, userId int64, hasSession b
 	return userID, nil
 }
 
-func (s *SpotifyService) identifyAndStoreUser(token string, userId int64, hasSession bool) (int64, error) {
+func (s *SpotifyService) identifyAndStoreUser(token string, refreshToken string, userId int64, hasSession bool) (int64, error) {
 	userProfile, err := s.fetchSpotifyProfile(token)
 	if err != nil {
 		log.Printf("Error fetching Spotify profile: %v", err)
@@ -151,14 +151,14 @@ func (s *SpotifyService) identifyAndStoreUser(token string, userId int64, hasSes
 			return 0, fmt.Errorf("user does not seem to exist")
 		} else {
 			// overwrite prev user
-			user, err = s.DB.AddSpotifySession(userId, userProfile.DisplayName, userProfile.Email, userProfile.ID, token, "", tokenExpiryTime)
+			user, err = s.DB.AddSpotifySession(userId, userProfile.DisplayName, userProfile.Email, userProfile.ID, token, refreshToken, tokenExpiryTime)
 			if err != nil {
 				log.Printf("Error adding Spotify session for user ID %d: %v", userId, err)
 				return 0, err
 			}
 		}
 	} else {
-		err = s.DB.UpdateUserToken(user.ID, token, "", tokenExpiryTime)
+		err = s.DB.UpdateUserToken(user.ID, token, refreshToken, tokenExpiryTime)
 		if err != nil {
 			// for now log and continue
 			log.Printf("Error updating user token for user ID %d: %v", user.ID, err)

--- a/service/spotify/spotify.go
+++ b/service/spotify/spotify.go
@@ -63,11 +63,13 @@ func (s *SpotifyService) SubmitTrackToPDS(did string, track *models.Track, ctx c
 		return fmt.Errorf("couldn't get Atproto session for DID %s: %w", did, err)
 	}
 
-	artistArr := make([]string, 0, len(track.Artist))
-	artistMbIdArr := make([]string, 0, len(track.Artist))
+	artists := make([]*teal.AlphaFeedDefs_Artist, 0, len(track.Artist))
 	for _, a := range track.Artist {
-		artistArr = append(artistArr, a.Name)
-		artistMbIdArr = append(artistMbIdArr, a.MBID)
+		artist := &teal.AlphaFeedDefs_Artist{
+			ArtistName: a.Name,
+			ArtistMbId: &a.MBID,
+		}
+		artists = append(artists, artist)
 	}
 
 	var durationPtr *int64
@@ -87,8 +89,7 @@ func (s *SpotifyService) SubmitTrackToPDS(did string, track *models.Track, ctx c
 		Duration:      durationPtr,
 		TrackName:     track.Name,
 		PlayedTime:    &playedTimeStr,
-		ArtistNames:   artistArr,
-		ArtistMbIds:   artistMbIdArr,
+		Artists:       artists,
 		ReleaseMbId:   &track.ReleaseMBID,
 		ReleaseName:   &track.Album,
 		RecordingMbId: &track.RecordingMBID,

--- a/service/spotify/spotify.go
+++ b/service/spotify/spotify.go
@@ -142,7 +142,7 @@ func (s *SpotifyService) identifyAndStoreUser(token string, refreshToken string,
 		return 0, err
 	}
 
-	tokenExpiryTime := time.Now().Add(1 * time.Hour) // Spotify tokens last ~1 hour
+	tokenExpiryTime := time.Now().UTC().Add(1 * time.Hour) // Spotify tokens last ~1 hour
 
 	// We don't intend users to log in via spotify!
 	if user == nil {
@@ -195,7 +195,7 @@ func (s *SpotifyService) LoadAllUsers() error {
 	count := 0
 	for _, user := range users {
 		// load users with valid tokens
-		if user.AccessToken != nil && user.TokenExpiry.After(time.Now()) {
+		if user.AccessToken != nil && user.TokenExpiry.After(time.Now().UTC()) {
 			s.userTokens[user.ID] = *user.AccessToken
 			count++
 		}
@@ -262,7 +262,7 @@ func (s *SpotifyService) refreshTokenInner(userID int64) (string, error) {
 		delete(s.userTokens, userID)
 		s.mu.Unlock()
 		// Also clear the bad refresh token from the DB
-		updateErr := s.DB.UpdateUserToken(userID, "", "", time.Now()) // Clear tokens
+		updateErr := s.DB.UpdateUserToken(userID, "", "", time.Now().UTC()) // Clear tokens
 		if updateErr != nil {
 			log.Printf("Failed to clear bad refresh token for user %d: %v", userID, updateErr)
 		}
@@ -281,7 +281,7 @@ func (s *SpotifyService) refreshTokenInner(userID int64) (string, error) {
 		return "", fmt.Errorf("failed to decode refresh response: %w", err)
 	}
 
-	newExpiry := time.Now().Add(time.Duration(tokenResponse.ExpiresIn) * time.Second)
+	newExpiry := time.Now().UTC().Add(time.Duration(tokenResponse.ExpiresIn) * time.Second)
 	newRefreshToken := *user.RefreshToken // Default to old one
 	if tokenResponse.RefreshToken != "" {
 		newRefreshToken = tokenResponse.RefreshToken // Use new one if provided

--- a/service/spotify/spotify.go
+++ b/service/spotify/spotify.go
@@ -72,7 +72,7 @@ func (s *SpotifyService) SubmitTrackToPDS(did string, track *models.Track, ctx c
 	for _, a := range track.Artist {
 		artist := &teal.AlphaFeedDefs_Artist{
 			ArtistName: a.Name,
-			ArtistMbId: &a.MBID,
+			ArtistMbId: a.MBID,
 		}
 		artists = append(artists, artist)
 	}
@@ -101,9 +101,9 @@ func (s *SpotifyService) SubmitTrackToPDS(did string, track *models.Track, ctx c
 		TrackName:     track.Name,
 		PlayedTime:    &playedTimeStr,
 		Artists:       artists,
-		ReleaseMbId:   &track.ReleaseMBID,
+		ReleaseMbId:   track.ReleaseMBID,
 		ReleaseName:   &track.Album,
-		RecordingMbId: &track.RecordingMBID,
+		RecordingMbId: track.RecordingMBID,
 		// Optional: Spotify specific data if your lexicon supports it
 		// SpotifyTrackID: &track.ServiceID,
 		// SpotifyAlbumID: &track.ServiceAlbumID,

--- a/session/session.go
+++ b/session/session.go
@@ -67,7 +67,7 @@ func (sm *SessionManager) CreateSession(userID int64) *Session {
 	rand.Read(b)
 	sessionID := base64.URLEncoding.EncodeToString(b)
 
-	now := time.Now()
+	now := time.Now().UTC()
 	expiresAt := now.Add(24 * time.Hour) // 24-hour session
 
 	session := &Session{
@@ -104,7 +104,7 @@ func (sm *SessionManager) GetSession(sessionID string) (*Session, bool) {
 
 	if exists {
 		// Check if session is expired
-		if time.Now().After(session.ExpiresAt) {
+		if time.Now().UTC().After(session.ExpiresAt) {
 			sm.DeleteSession(sessionID)
 			return nil, false
 		}
@@ -124,7 +124,7 @@ func (sm *SessionManager) GetSession(sessionID string) (*Session, bool) {
 			return nil, false
 		}
 
-		if time.Now().After(session.ExpiresAt) {
+		if time.Now().UTC().After(session.ExpiresAt) {
 			sm.DeleteSession(sessionID)
 			return nil, false
 		}

--- a/util/gencbor/gencbor.go
+++ b/util/gencbor/gencbor.go
@@ -28,6 +28,7 @@ func main() {
 			teal.AlphaActorStatus{},
 			teal.AlphaActorProfile_FeaturedItem{},
 			teal.AlphaFeedDefs_PlayView{},
+			teal.AlphaFeedDefs_Artist{},
 		); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Misc
- Resolved the DID mix up. It had a `OR ID` so was always true and returning the top user in the db causing that to be the only PDS that tracks got sent to
- Standardized time across the board to `.UTC()` because `time.now()` was doing local time
- Commented out or changed the wording for anywhere printing credentials so it wont be in the logs since there has been some chatter about a public instance 

Spotify
- Record refreshtoken on login
- Load and unload users each loop and at the start checks if the token is expired, if it is it refreshes it

Have tested a bit but plan on leaving it on over the weekend to see if anything else comes up 