### PR TITLE
 add status support + mb endpoint

### DIFF
--- a/cmd/listenbrainz_test.go
+++ b/cmd/listenbrainz_test.go
@@ -1,0 +1,539 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/teal-fm/piper/db"
+	"github.com/teal-fm/piper/models"
+	"github.com/teal-fm/piper/session"
+)
+
+func setupTestDB(t *testing.T) *db.DB {
+	// Use in-memory SQLite database for testing
+	database, err := db.New(":memory:")
+	if err != nil {
+		t.Fatalf("Failed to create test database: %v", err)
+	}
+
+	if err := database.Initialize(); err != nil {
+		t.Fatalf("Failed to initialize test database: %v", err)
+	}
+
+	return database
+}
+
+func createTestUser(t *testing.T, database *db.DB) (int64, string) {
+	// Create a test user
+	user := &models.User{
+		Email:      func() *string { s := "test@example.com"; return &s }(),
+		ATProtoDID: func() *string { s := "did:test:user"; return &s }(),
+	}
+
+	userID, err := database.CreateUser(user)
+	if err != nil {
+		t.Fatalf("Failed to create test user: %v", err)
+	}
+
+	// Create API key for the user
+	sessionManager := session.NewSessionManager(database)
+	apiKeyObj, err := sessionManager.CreateAPIKey(userID, "test-key", 30) // 30 days validity
+	if err != nil {
+		t.Fatalf("Failed to create API key: %v", err)
+	}
+
+	return userID, apiKeyObj.ID
+}
+
+// Helper to create context with user ID (simulating auth middleware)
+func withUserContext(ctx context.Context, userID int64) context.Context {
+	return session.WithUserID(ctx, userID)
+}
+
+func TestListenBrainzSubmission_Success(t *testing.T) {
+	database := setupTestDB(t)
+	defer database.Close()
+
+	userID, apiKey := createTestUser(t, database)
+
+	// Create test submission
+	submission := models.ListenBrainzSubmission{
+		ListenType: "single",
+		Payload: []models.ListenBrainzPayload{
+			{
+				ListenedAt: func() *int64 { i := int64(1704067200); return &i }(),
+				TrackMetadata: models.ListenBrainzTrackMetadata{
+					ArtistName:  "Daft Punk",
+					TrackName:   "One More Time",
+					ReleaseName: func() *string { s := "Discovery"; return &s }(),
+					AdditionalInfo: &models.ListenBrainzAdditionalInfo{
+						RecordingMBID: func() *string { s := "98255a8c-017a-4bc7-8dd6-1fa36124572b"; return &s }(),
+						ArtistMBIDs:   []string{"db92a151-1ac2-438b-bc43-b82e149ddd50"},
+						ReleaseMBID:   func() *string { s := "bf9e91ea-8029-4a04-a26a-224e00a83266"; return &s }(),
+						DurationMs:    func() *int64 { i := int64(320000); return &i }(),
+						SpotifyID:     func() *string { s := "4PTG3Z6ehGkBFwjybzWkR8"; return &s }(),
+						ISRC:          func() *string { s := "GBARL0600925"; return &s }(),
+					},
+				},
+			},
+		},
+	}
+
+	jsonData, err := json.Marshal(submission)
+	if err != nil {
+		t.Fatalf("Failed to marshal submission: %v", err)
+	}
+
+	// Create request
+	req := httptest.NewRequest(http.MethodPost, "/1/submit-listens", bytes.NewReader(jsonData))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Token "+apiKey)
+
+	// Add user context (simulating authentication middleware)
+	ctx := withUserContext(req.Context(), userID)
+	req = req.WithContext(ctx)
+
+	// Create response recorder
+	rr := httptest.NewRecorder()
+
+	// Call handler
+	handler := apiSubmitListensHandler(database)
+	handler(rr, req)
+
+	// Check response
+	if rr.Code != http.StatusOK {
+		t.Errorf("Expected status %d, got %d. Body: %s", http.StatusOK, rr.Code, rr.Body.String())
+	}
+
+	// Parse response
+	var response map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+
+	// Verify response
+	if response["status"] != "ok" {
+		t.Errorf("Expected status 'ok', got %v", response["status"])
+	}
+
+	processed, ok := response["processed"].(float64)
+	if !ok || processed != 1 {
+		t.Errorf("Expected processed count 1, got %v", response["processed"])
+	}
+
+	// Verify data was saved to database
+	tracks, err := database.GetRecentTracks(userID, 10)
+	if err != nil {
+		t.Fatalf("Failed to get tracks from database: %v", err)
+	}
+
+	if len(tracks) != 1 {
+		t.Fatalf("Expected 1 track in database, got %d", len(tracks))
+	}
+
+	track := tracks[0]
+	if track.Name != "One More Time" {
+		t.Errorf("Expected track name 'One More Time', got %s", track.Name)
+	}
+	if len(track.Artist) == 0 || track.Artist[0].Name != "Daft Punk" {
+		t.Errorf("Expected artist 'Daft Punk', got %v", track.Artist)
+	}
+	if track.Album != "Discovery" {
+		t.Errorf("Expected album 'Discovery', got %s", track.Album)
+	}
+	if track.RecordingMBID == nil || *track.RecordingMBID != "98255a8c-017a-4bc7-8dd6-1fa36124572b" {
+		t.Errorf("Expected recording MBID to be set correctly")
+	}
+	if track.DurationMs != 320000 {
+		t.Errorf("Expected duration 320000ms, got %d", track.DurationMs)
+	}
+}
+
+func TestListenBrainzSubmission_MinimalPayload(t *testing.T) {
+	database := setupTestDB(t)
+	defer database.Close()
+
+	userID, apiKey := createTestUser(t, database)
+
+	// Create minimal submission (only required fields)
+	submission := models.ListenBrainzSubmission{
+		ListenType: "single",
+		Payload: []models.ListenBrainzPayload{
+			{
+				TrackMetadata: models.ListenBrainzTrackMetadata{
+					ArtistName: "The Beatles",
+					TrackName:  "Hey Jude",
+				},
+			},
+		},
+	}
+
+	jsonData, err := json.Marshal(submission)
+	if err != nil {
+		t.Fatalf("Failed to marshal submission: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/1/submit-listens", bytes.NewReader(jsonData))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Token "+apiKey)
+
+	ctx := withUserContext(req.Context(), userID)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	handler := apiSubmitListensHandler(database)
+	handler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("Expected status %d, got %d. Body: %s", http.StatusOK, rr.Code, rr.Body.String())
+	}
+
+	// Verify track was saved
+	tracks, err := database.GetRecentTracks(userID, 10)
+	if err != nil {
+		t.Fatalf("Failed to get tracks from database: %v", err)
+	}
+
+	if len(tracks) != 1 {
+		t.Fatalf("Expected 1 track in database, got %d", len(tracks))
+	}
+
+	track := tracks[0]
+	if track.Name != "Hey Jude" {
+		t.Errorf("Expected track name 'Hey Jude', got %s", track.Name)
+	}
+	if len(track.Artist) == 0 || track.Artist[0].Name != "The Beatles" {
+		t.Errorf("Expected artist 'The Beatles', got %v", track.Artist)
+	}
+	// Timestamp should be set to current time if not provided
+	if track.Timestamp.IsZero() {
+		t.Error("Expected timestamp to be set")
+	}
+}
+
+func TestListenBrainzSubmission_BulkImport(t *testing.T) {
+	database := setupTestDB(t)
+	defer database.Close()
+
+	userID, apiKey := createTestUser(t, database)
+
+	// Create bulk submission
+	submission := models.ListenBrainzSubmission{
+		ListenType: "import",
+		Payload: []models.ListenBrainzPayload{
+			{
+				ListenedAt: func() *int64 { i := int64(1704067200); return &i }(),
+				TrackMetadata: models.ListenBrainzTrackMetadata{
+					ArtistName: "Track One Artist",
+					TrackName:  "Track One",
+				},
+			},
+			{
+				ListenedAt: func() *int64 { i := int64(1704067300); return &i }(),
+				TrackMetadata: models.ListenBrainzTrackMetadata{
+					ArtistName: "Track Two Artist",
+					TrackName:  "Track Two",
+				},
+			},
+			{
+				ListenedAt: func() *int64 { i := int64(1704067400); return &i }(),
+				TrackMetadata: models.ListenBrainzTrackMetadata{
+					ArtistName: "Track Three Artist",
+					TrackName:  "Track Three",
+				},
+			},
+		},
+	}
+
+	jsonData, err := json.Marshal(submission)
+	if err != nil {
+		t.Fatalf("Failed to marshal submission: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/1/submit-listens", bytes.NewReader(jsonData))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Token "+apiKey)
+
+	ctx := withUserContext(req.Context(), userID)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	handler := apiSubmitListensHandler(database)
+	handler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("Expected status %d, got %d. Body: %s", http.StatusOK, rr.Code, rr.Body.String())
+	}
+
+	// Parse response
+	var response map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+
+	processed, ok := response["processed"].(float64)
+	if !ok || processed != 3 {
+		t.Errorf("Expected processed count 3, got %v", response["processed"])
+	}
+
+	// Verify all tracks were saved
+	tracks, err := database.GetRecentTracks(userID, 10)
+	if err != nil {
+		t.Fatalf("Failed to get tracks from database: %v", err)
+	}
+
+	if len(tracks) != 3 {
+		t.Fatalf("Expected 3 tracks in database, got %d", len(tracks))
+	}
+}
+
+func TestListenBrainzSubmission_PlayingNow(t *testing.T) {
+	database := setupTestDB(t)
+	defer database.Close()
+
+	userID, apiKey := createTestUser(t, database)
+
+	// Create playing_now submission
+	submission := models.ListenBrainzSubmission{
+		ListenType: "playing_now",
+		Payload: []models.ListenBrainzPayload{
+			{
+				TrackMetadata: models.ListenBrainzTrackMetadata{
+					ArtistName: "Current Artist",
+					TrackName:  "Currently Playing",
+				},
+			},
+		},
+	}
+
+	jsonData, err := json.Marshal(submission)
+	if err != nil {
+		t.Fatalf("Failed to marshal submission: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/1/submit-listens", bytes.NewReader(jsonData))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Token "+apiKey)
+
+	ctx := withUserContext(req.Context(), userID)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	handler := apiSubmitListensHandler(database)
+	handler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("Expected status %d, got %d. Body: %s", http.StatusOK, rr.Code, rr.Body.String())
+	}
+
+	// playing_now tracks should not be permanently stored
+	tracks, err := database.GetRecentTracks(userID, 10)
+	if err != nil {
+		t.Fatalf("Failed to get tracks from database: %v", err)
+	}
+
+	if len(tracks) != 0 {
+		t.Errorf("Expected 0 tracks in database for playing_now, got %d", len(tracks))
+	}
+}
+
+func TestListenBrainzSubmission_ValidationErrors(t *testing.T) {
+	database := setupTestDB(t)
+	defer database.Close()
+
+	userID, apiKey := createTestUser(t, database)
+
+	testCases := []struct {
+		name           string
+		submission     models.ListenBrainzSubmission
+		expectedStatus int
+		expectedError  string
+	}{
+		{
+			name: "invalid_listen_type",
+			submission: models.ListenBrainzSubmission{
+				ListenType: "invalid",
+				Payload:    []models.ListenBrainzPayload{},
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "Invalid listen_type",
+		},
+		{
+			name: "empty_payload",
+			submission: models.ListenBrainzSubmission{
+				ListenType: "single",
+				Payload:    []models.ListenBrainzPayload{},
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "Payload cannot be empty",
+		},
+		{
+			name: "missing_artist_name",
+			submission: models.ListenBrainzSubmission{
+				ListenType: "single",
+				Payload: []models.ListenBrainzPayload{
+					{
+						TrackMetadata: models.ListenBrainzTrackMetadata{
+							TrackName: "Track Without Artist",
+						},
+					},
+				},
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "artist_name is required",
+		},
+		{
+			name: "missing_track_name",
+			submission: models.ListenBrainzSubmission{
+				ListenType: "single",
+				Payload: []models.ListenBrainzPayload{
+					{
+						TrackMetadata: models.ListenBrainzTrackMetadata{
+							ArtistName: "Artist Without Track",
+						},
+					},
+				},
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "track_name is required",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			jsonData, err := json.Marshal(tc.submission)
+			if err != nil {
+				t.Fatalf("Failed to marshal submission: %v", err)
+			}
+
+			req := httptest.NewRequest(http.MethodPost, "/1/submit-listens", bytes.NewReader(jsonData))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Token "+apiKey)
+
+			ctx := withUserContext(req.Context(), userID)
+			req = req.WithContext(ctx)
+
+			rr := httptest.NewRecorder()
+			handler := apiSubmitListensHandler(database)
+			handler(rr, req)
+
+			if rr.Code != tc.expectedStatus {
+				t.Errorf("Expected status %d, got %d. Body: %s", tc.expectedStatus, rr.Code, rr.Body.String())
+			}
+
+			if tc.expectedError != "" {
+				body := rr.Body.String()
+				if !bytes.Contains([]byte(body), []byte(tc.expectedError)) {
+					t.Errorf("Expected error containing '%s', got: %s", tc.expectedError, body)
+				}
+			}
+		})
+	}
+}
+
+func TestListenBrainzSubmission_Unauthorized(t *testing.T) {
+	database := setupTestDB(t)
+	defer database.Close()
+
+	submission := models.ListenBrainzSubmission{
+		ListenType: "single",
+		Payload: []models.ListenBrainzPayload{
+			{
+				TrackMetadata: models.ListenBrainzTrackMetadata{
+					ArtistName: "Test Artist",
+					TrackName:  "Test Track",
+				},
+			},
+		},
+	}
+
+	jsonData, err := json.Marshal(submission)
+	if err != nil {
+		t.Fatalf("Failed to marshal submission: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/1/submit-listens", bytes.NewReader(jsonData))
+	req.Header.Set("Content-Type", "application/json")
+	// No Authorization header
+
+	rr := httptest.NewRecorder()
+	handler := apiSubmitListensHandler(database)
+	handler(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("Expected status %d, got %d", http.StatusUnauthorized, rr.Code)
+	}
+}
+
+func TestListenBrainzDataConversion(t *testing.T) {
+	// Test the conversion logic directly
+	payload := models.ListenBrainzPayload{
+		ListenedAt: func() *int64 { i := int64(1704067200); return &i }(),
+		TrackMetadata: models.ListenBrainzTrackMetadata{
+			ArtistName:  "Test Artist",
+			TrackName:   "Test Track",
+			ReleaseName: func() *string { s := "Test Album"; return &s }(),
+			AdditionalInfo: &models.ListenBrainzAdditionalInfo{
+				RecordingMBID: func() *string { s := "test-recording-mbid"; return &s }(),
+				ArtistMBIDs:   []string{"test-artist-mbid-1", "test-artist-mbid-2"},
+				ReleaseMBID:   func() *string { s := "test-release-mbid"; return &s }(),
+				DurationMs:    func() *int64 { i := int64(240000); return &i }(),
+				SpotifyID:     func() *string { s := "test-spotify-id"; return &s }(),
+				ISRC:          func() *string { s := "TEST1234567"; return &s }(),
+			},
+		},
+	}
+
+	track := payload.ConvertToTrack(123)
+
+	// Verify conversion
+	if track.Name != "Test Track" {
+		t.Errorf("Expected track name 'Test Track', got %s", track.Name)
+	}
+	if track.Album != "Test Album" {
+		t.Errorf("Expected album 'Test Album', got %s", track.Album)
+	}
+	if track.RecordingMBID == nil || *track.RecordingMBID != "test-recording-mbid" {
+		t.Errorf("Recording MBID not set correctly")
+	}
+	if track.ReleaseMBID == nil || *track.ReleaseMBID != "test-release-mbid" {
+		t.Errorf("Release MBID not set correctly")
+	}
+	if track.DurationMs != 240000 {
+		t.Errorf("Expected duration 240000ms, got %d", track.DurationMs)
+	}
+	if track.ISRC != "TEST1234567" {
+		t.Errorf("Expected ISRC 'TEST1234567', got %s", track.ISRC)
+	}
+	if track.URL != "https://open.spotify.com/track/test-spotify-id" {
+		t.Errorf("Expected Spotify URL to be constructed correctly, got %s", track.URL)
+	}
+	if track.ServiceBaseUrl != "spotify" {
+		t.Errorf("Expected service 'spotify', got %s", track.ServiceBaseUrl)
+	}
+
+	expectedTime := time.Unix(1704067200, 0)
+	if !track.Timestamp.Equal(expectedTime) {
+		t.Errorf("Expected timestamp %v, got %v", expectedTime, track.Timestamp)
+	}
+
+	if !track.HasStamped {
+		t.Error("Expected HasStamped to be true for external submissions")
+	}
+
+	// Check artists
+	if len(track.Artist) != 2 {
+		t.Errorf("Expected 2 artists, got %d", len(track.Artist))
+	}
+	if track.Artist[0].MBID == nil || *track.Artist[0].MBID != "test-artist-mbid-1" {
+		t.Errorf("First artist MBID not set correctly")
+	}
+	if track.Artist[1].MBID == nil || *track.Artist[1].MBID != "test-artist-mbid-2" {
+		t.Errorf("Second artist MBID not set correctly")
+	}
+}

--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -36,6 +36,9 @@ func (app *application) routes() http.Handler {
 	mux.HandleFunc("/api/v1/history", session.WithAPIAuth(apiTrackHistory(app.spotifyService), app.sessionManager))       // Spotify History
 	mux.HandleFunc("/api/v1/musicbrainz/search", apiMusicBrainzSearch(app.mbService))                                     // MusicBrainz (public?)
 
+	// ListenBrainz-compatible endpoint
+	mux.HandleFunc("/1/submit-listens", session.WithAPIAuth(apiSubmitListensHandler(app.database), app.sessionManager))
+
 	serverUrlRoot := viper.GetString("server.root_url")
 	atpClientId := viper.GetString("atproto.client_id")
 	atpCallbackUrl := viper.GetString("atproto.callback_url")

--- a/models/listenbrainz.go
+++ b/models/listenbrainz.go
@@ -1,0 +1,122 @@
+package models
+
+import "time"
+
+// ListenBrainzSubmission represents the top-level submission format
+type ListenBrainzSubmission struct {
+	ListenType string                `json:"listen_type"`
+	Payload    []ListenBrainzPayload `json:"payload"`
+}
+
+// ListenBrainzPayload represents individual listen data
+type ListenBrainzPayload struct {
+	ListenedAt    *int64                    `json:"listened_at,omitempty"`
+	TrackMetadata ListenBrainzTrackMetadata `json:"track_metadata"`
+}
+
+// ListenBrainzTrackMetadata contains the track information
+type ListenBrainzTrackMetadata struct {
+	ArtistName     string                      `json:"artist_name"`
+	TrackName      string                      `json:"track_name"`
+	ReleaseName    *string                     `json:"release_name,omitempty"`
+	AdditionalInfo *ListenBrainzAdditionalInfo `json:"additional_info,omitempty"`
+}
+
+// ListenBrainzAdditionalInfo contains optional metadata
+type ListenBrainzAdditionalInfo struct {
+	MediaPlayer             *string  `json:"media_player,omitempty"`
+	SubmissionClient        *string  `json:"submission_client,omitempty"`
+	SubmissionClientVersion *string  `json:"submission_client_version,omitempty"`
+	RecordingMBID           *string  `json:"recording_mbid,omitempty"`
+	ArtistMBIDs             []string `json:"artist_mbids,omitempty"`
+	ReleaseMBID             *string  `json:"release_mbid,omitempty"`
+	ReleaseGroupMBID        *string  `json:"release_group_mbid,omitempty"`
+	TrackMBID               *string  `json:"track_mbid,omitempty"`
+	WorkMBIDs               []string `json:"work_mbids,omitempty"`
+	Tags                    []string `json:"tags,omitempty"`
+	DurationMs              *int64   `json:"duration_ms,omitempty"`
+	SpotifyID               *string  `json:"spotify_id,omitempty"`
+	ISRC                    *string  `json:"isrc,omitempty"`
+	TrackNumber             *int     `json:"tracknumber,omitempty"`
+	DiscNumber              *int     `json:"discnumber,omitempty"`
+	MusicService            *string  `json:"music_service,omitempty"`
+	MusicServiceName        *string  `json:"music_service_name,omitempty"`
+	OriginURL               *string  `json:"origin_url,omitempty"`
+	LastFMTrackURL          *string  `json:"lastfm_track_url,omitempty"`
+	YoutubeID               *string  `json:"youtube_id,omitempty"`
+}
+
+// ConvertToTrack converts ListenBrainz format to internal Track format
+func (lbp *ListenBrainzPayload) ConvertToTrack(userID int64) Track {
+	track := Track{
+		Name:   lbp.TrackMetadata.TrackName,
+		Artist: []Artist{{Name: lbp.TrackMetadata.ArtistName}},
+	}
+
+	// Set timestamp
+	if lbp.ListenedAt != nil {
+		track.Timestamp = time.Unix(*lbp.ListenedAt, 0)
+	} else {
+		track.Timestamp = time.Now()
+	}
+
+	// Set album/release name
+	if lbp.TrackMetadata.ReleaseName != nil {
+		track.Album = *lbp.TrackMetadata.ReleaseName
+	}
+
+	// Handle additional info if present
+	if info := lbp.TrackMetadata.AdditionalInfo; info != nil {
+		// Set MBIDs
+		if info.RecordingMBID != nil {
+			track.RecordingMBID = info.RecordingMBID
+		}
+		if info.ReleaseMBID != nil {
+			track.ReleaseMBID = info.ReleaseMBID
+		}
+
+		// Set duration
+		if info.DurationMs != nil {
+			track.DurationMs = *info.DurationMs
+		}
+
+		// Set ISRC
+		if info.ISRC != nil {
+			track.ISRC = *info.ISRC
+		}
+
+		// Handle multiple artists from MBIDs
+		if len(info.ArtistMBIDs) > 0 {
+			artists := make([]Artist, len(info.ArtistMBIDs))
+			for i, mbid := range info.ArtistMBIDs {
+				artists[i] = Artist{
+					Name: lbp.TrackMetadata.ArtistName, // Use main artist name
+					MBID: &mbid,
+				}
+			}
+			track.Artist = artists
+		}
+
+		// Set service information
+		if info.MusicService != nil {
+			track.ServiceBaseUrl = *info.MusicService
+		}
+		if info.OriginURL != nil {
+			track.URL = *info.OriginURL
+		}
+		if info.SpotifyID != nil {
+			track.URL = "https://open.spotify.com/track/" + *info.SpotifyID
+			track.ServiceBaseUrl = "spotify"
+		}
+	}
+
+	// Default service if not set
+	if track.ServiceBaseUrl == "" {
+		track.ServiceBaseUrl = "listenbrainz"
+	}
+
+	// Mark as stamped since it came from external submission
+	track.HasStamped = true
+
+	return track
+}

--- a/service/playingnow/playingnow.go
+++ b/service/playingnow/playingnow.go
@@ -158,6 +158,8 @@ func (p *PlayingNowService) ClearPlayingNow(ctx context.Context, userID int64) e
 	}
 
 	// Update the record
+	//TODO this is failing with InvalidSwap: Record was at "prevouis cid"
+	//2025/09/22 08:03:29 spotify: Updated!
 	input := atproto.RepoPutRecord_Input{
 		Collection: "fm.teal.alpha.actor.status",
 		Repo:       sess.DID,

--- a/service/playingnow/playingnow.go
+++ b/service/playingnow/playingnow.go
@@ -1,0 +1,250 @@
+package playingnow
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/bluesky-social/indigo/api/atproto"
+	lexutil "github.com/bluesky-social/indigo/lex/util"
+	"github.com/bluesky-social/indigo/xrpc"
+	"github.com/spf13/viper"
+	"github.com/teal-fm/piper/api/teal"
+	"github.com/teal-fm/piper/db"
+	"github.com/teal-fm/piper/models"
+	atprotoauth "github.com/teal-fm/piper/oauth/atproto"
+)
+
+// PlayingNowService handles publishing current playing status to ATProto
+type PlayingNowService struct {
+	db             *db.DB
+	atprotoService *atprotoauth.ATprotoAuthService
+	logger         *log.Logger
+}
+
+// NewPlayingNowService creates a new playing now service
+func NewPlayingNowService(database *db.DB, atprotoService *atprotoauth.ATprotoAuthService) *PlayingNowService {
+	logger := log.New(os.Stdout, "playingnow: ", log.LstdFlags|log.Lmsgprefix)
+
+	return &PlayingNowService{
+		db:             database,
+		atprotoService: atprotoService,
+		logger:         logger,
+	}
+}
+
+// PublishPlayingNow publishes a currently playing track as actor status
+func (p *PlayingNowService) PublishPlayingNow(ctx context.Context, userID int64, track *models.Track) error {
+	// Get user information to find their DID
+	user, err := p.db.GetUserByID(userID)
+	if err != nil {
+		return fmt.Errorf("failed to get user: %w", err)
+	}
+
+	if user.ATProtoDID == nil {
+		p.logger.Printf("User %d has no ATProto DID, skipping playing now", userID)
+		return nil
+	}
+
+	did := *user.ATProtoDID
+
+	// Get ATProto client
+	client, err := p.atprotoService.GetATProtoClient()
+	if err != nil || client == nil {
+		return fmt.Errorf("failed to get ATProto client: %w", err)
+	}
+
+	xrpcClient := p.atprotoService.GetXrpcClient()
+	if xrpcClient == nil {
+		return fmt.Errorf("xrpc client is not available")
+	}
+
+	// Get user session
+	sess, err := p.db.GetAtprotoSession(did, ctx, *client)
+	if err != nil {
+		return fmt.Errorf("couldn't get Atproto session for DID %s: %w", did, err)
+	}
+
+	// Convert track to PlayView format
+	playView, err := p.trackToPlayView(track)
+	if err != nil {
+		return fmt.Errorf("failed to convert track to PlayView: %w", err)
+	}
+
+	// Create actor status record
+	now := time.Now()
+	expiry := now.Add(10 * time.Minute) // Default 10 minutes as mentioned in schema
+
+	status := &teal.AlphaActorStatus{
+		LexiconTypeID: "fm.teal.alpha.actor.status",
+		Time:          strconv.FormatInt(now.Unix(), 10),
+		Expiry:        func() *string { s := strconv.FormatInt(expiry.Unix(), 10); return &s }(),
+		Item:          playView,
+	}
+
+	// Create the record input
+	input := atproto.RepoPutRecord_Input{
+		Collection: "fm.teal.alpha.actor.status",
+		Repo:       sess.DID,
+		Rkey:       "self", // Use "self" as the record key for current status
+		Record:     &lexutil.LexiconTypeDecoder{Val: status},
+	}
+
+	authArgs := db.AtpSessionToAuthArgs(sess)
+
+	// Submit to PDS
+	var out atproto.RepoPutRecord_Output
+	if err := xrpcClient.Do(ctx, authArgs, xrpc.Procedure, "application/json", "com.atproto.repo.putRecord", nil, input, &out); err != nil {
+		p.logger.Printf("Error creating playing now status for DID %s: %v", did, err)
+		return fmt.Errorf("failed to create playing now status for DID %s: %w", did, err)
+	}
+
+	p.logger.Printf("Successfully published playing now status for user %d (DID: %s): %s - %s",
+		userID, did, track.Artist[0].Name, track.Name)
+
+	return nil
+}
+
+// ClearPlayingNow removes the current playing status by setting an expired status
+func (p *PlayingNowService) ClearPlayingNow(ctx context.Context, userID int64) error {
+	// Get user information
+	user, err := p.db.GetUserByID(userID)
+	if err != nil {
+		return fmt.Errorf("failed to get user: %w", err)
+	}
+
+	if user.ATProtoDID == nil {
+		p.logger.Printf("User %d has no ATProto DID, skipping clear playing now", userID)
+		return nil
+	}
+
+	did := *user.ATProtoDID
+
+	// Get ATProto clients
+	client, err := p.atprotoService.GetATProtoClient()
+	if err != nil || client == nil {
+		return fmt.Errorf("failed to get ATProto client: %w", err)
+	}
+
+	xrpcClient := p.atprotoService.GetXrpcClient()
+	if xrpcClient == nil {
+		return fmt.Errorf("xrpc client is not available")
+	}
+
+	// Get user session
+	sess, err := p.db.GetAtprotoSession(did, ctx, *client)
+	if err != nil {
+		return fmt.Errorf("couldn't get Atproto session for DID %s: %w", did, err)
+	}
+
+	// Create an expired status (essentially clearing it)
+	now := time.Now()
+	expiredTime := now.Add(-1 * time.Minute) // Set expiry to 1 minute ago
+
+	// Create empty play view
+	emptyPlayView := &teal.AlphaFeedDefs_PlayView{
+		TrackName: "", // Empty track indicates no current playing
+		Artists:   []*teal.AlphaFeedDefs_Artist{},
+	}
+
+	status := &teal.AlphaActorStatus{
+		LexiconTypeID: "fm.teal.alpha.actor.status",
+		Time:          strconv.FormatInt(now.Unix(), 10),
+		Expiry:        func() *string { s := strconv.FormatInt(expiredTime.Unix(), 10); return &s }(),
+		Item:          emptyPlayView,
+	}
+
+	// Update the record
+	input := atproto.RepoPutRecord_Input{
+		Collection: "fm.teal.alpha.actor.status",
+		Repo:       sess.DID,
+		Rkey:       "self",
+		Record:     &lexutil.LexiconTypeDecoder{Val: status},
+	}
+
+	authArgs := db.AtpSessionToAuthArgs(sess)
+
+	var out atproto.RepoPutRecord_Output
+	if err := xrpcClient.Do(ctx, authArgs, xrpc.Procedure, "application/json", "com.atproto.repo.putRecord", nil, input, &out); err != nil {
+		p.logger.Printf("Error clearing playing now status for DID %s: %v", did, err)
+		return fmt.Errorf("failed to clear playing now status for DID %s: %w", did, err)
+	}
+
+	p.logger.Printf("Successfully cleared playing now status for user %d (DID: %s)", userID, did)
+	return nil
+}
+
+// trackToPlayView converts a models.Track to teal.AlphaFeedDefs_PlayView
+func (p *PlayingNowService) trackToPlayView(track *models.Track) (*teal.AlphaFeedDefs_PlayView, error) {
+	if track.Name == "" {
+		return nil, fmt.Errorf("track name cannot be empty")
+	}
+
+	// Convert artists
+	artists := make([]*teal.AlphaFeedDefs_Artist, 0, len(track.Artist))
+	for _, a := range track.Artist {
+		artist := &teal.AlphaFeedDefs_Artist{
+			ArtistName: a.Name,
+			ArtistMbId: a.MBID,
+		}
+		artists = append(artists, artist)
+	}
+
+	// Prepare optional fields
+	var durationPtr *int64
+	if track.DurationMs > 0 {
+		durationSeconds := track.DurationMs / 1000
+		durationPtr = &durationSeconds
+	}
+
+	var playedTimeStr *string
+	if !track.Timestamp.IsZero() {
+		timeStr := track.Timestamp.Format(time.RFC3339)
+		playedTimeStr = &timeStr
+	}
+
+	var isrcPtr *string
+	if track.ISRC != "" {
+		isrcPtr = &track.ISRC
+	}
+
+	var originUrlPtr *string
+	if track.URL != "" {
+		originUrlPtr = &track.URL
+	}
+
+	var servicePtr *string
+	if track.ServiceBaseUrl != "" {
+		servicePtr = &track.ServiceBaseUrl
+	}
+
+	var releaseNamePtr *string
+	if track.Album != "" {
+		releaseNamePtr = &track.Album
+	}
+
+	// Get submission client agent
+	submissionAgent := viper.GetString("app.submission_agent")
+	if submissionAgent == "" {
+		submissionAgent = "piper/v0.0.1"
+	}
+
+	playView := &teal.AlphaFeedDefs_PlayView{
+		TrackName:              track.Name,
+		Artists:                artists,
+		Duration:               durationPtr,
+		PlayedTime:             playedTimeStr,
+		RecordingMbId:          track.RecordingMBID,
+		ReleaseMbId:            track.ReleaseMBID,
+		ReleaseName:            releaseNamePtr,
+		Isrc:                   isrcPtr,
+		OriginUrl:              originUrlPtr,
+		MusicServiceBaseDomain: servicePtr,
+		SubmissionClientAgent:  &submissionAgent,
+	}
+
+	return playView, nil
+}

--- a/service/playingnow/playingnow_test.go
+++ b/service/playingnow/playingnow_test.go
@@ -1,0 +1,144 @@
+package playingnow
+
+import (
+	"testing"
+	"time"
+
+	"github.com/teal-fm/piper/db"
+	"github.com/teal-fm/piper/models"
+)
+
+func TestTrackToPlayView(t *testing.T) {
+	// Create a mock playing now service (we'll test the conversion logic)
+	database, err := db.New(":memory:")
+	if err != nil {
+		t.Fatalf("Failed to create test database: %v", err)
+	}
+	defer database.Close()
+
+	if err := database.Initialize(); err != nil {
+		t.Fatalf("Failed to initialize test database: %v", err)
+	}
+
+	// Mock ATProto service (we'll just test the conversion, not the actual submission)
+	service := &PlayingNowService{
+		db:     database,
+		logger: nil, // We'll skip logging in tests
+	}
+
+	// Create a test track
+	track := &models.Track{
+		Name: "Test Track",
+		Artist: []models.Artist{
+			{
+				Name: "Test Artist",
+				MBID: func() *string { s := "test-artist-mbid"; return &s }(),
+			},
+		},
+		Album:          "Test Album",
+		DurationMs:     240000, // 4 minutes
+		Timestamp:      time.Now(),
+		ServiceBaseUrl: "spotify",
+		URL:            "https://open.spotify.com/track/test",
+		RecordingMBID:  func() *string { s := "test-recording-mbid"; return &s }(),
+		ReleaseMBID:    func() *string { s := "test-release-mbid"; return &s }(),
+		ISRC:           "TEST1234567",
+	}
+
+	// Test the conversion
+	playView, err := service.trackToPlayView(track)
+	if err != nil {
+		t.Fatalf("Failed to convert track to PlayView: %v", err)
+	}
+
+	// Verify the conversion
+	if playView.TrackName != "Test Track" {
+		t.Errorf("Expected track name 'Test Track', got %s", playView.TrackName)
+	}
+
+	if len(playView.Artists) != 1 {
+		t.Errorf("Expected 1 artist, got %d", len(playView.Artists))
+	} else {
+		if playView.Artists[0].ArtistName != "Test Artist" {
+			t.Errorf("Expected artist name 'Test Artist', got %s", playView.Artists[0].ArtistName)
+		}
+		if playView.Artists[0].ArtistMbId == nil || *playView.Artists[0].ArtistMbId != "test-artist-mbid" {
+			t.Errorf("Artist MBID not set correctly")
+		}
+	}
+
+	if playView.ReleaseName == nil || *playView.ReleaseName != "Test Album" {
+		t.Errorf("Release name not set correctly")
+	}
+
+	if playView.Duration == nil || *playView.Duration != 240 {
+		t.Errorf("Expected duration 240 seconds, got %v", playView.Duration)
+	}
+
+	if playView.RecordingMbId == nil || *playView.RecordingMbId != "test-recording-mbid" {
+		t.Errorf("Recording MBID not set correctly")
+	}
+
+	if playView.ReleaseMbId == nil || *playView.ReleaseMbId != "test-release-mbid" {
+		t.Errorf("Release MBID not set correctly")
+	}
+
+	if playView.Isrc == nil || *playView.Isrc != "TEST1234567" {
+		t.Errorf("ISRC not set correctly")
+	}
+
+	if playView.OriginUrl == nil || *playView.OriginUrl != "https://open.spotify.com/track/test" {
+		t.Errorf("Origin URL not set correctly")
+	}
+
+	if playView.MusicServiceBaseDomain == nil || *playView.MusicServiceBaseDomain != "spotify" {
+		t.Errorf("Music service not set correctly")
+	}
+}
+
+func TestTrackToPlayViewEmptyTrack(t *testing.T) {
+	service := &PlayingNowService{}
+
+	// Test with empty track name (should fail)
+	track := &models.Track{
+		Name:   "", // Empty name should cause error
+		Artist: []models.Artist{{Name: "Test Artist"}},
+	}
+
+	_, err := service.trackToPlayView(track)
+	if err == nil {
+		t.Error("Expected error for empty track name, got nil")
+	}
+}
+
+func TestTrackToPlayViewMinimal(t *testing.T) {
+	service := &PlayingNowService{}
+
+	// Test with minimal track data
+	track := &models.Track{
+		Name:   "Minimal Track",
+		Artist: []models.Artist{{Name: "Minimal Artist"}},
+	}
+
+	playView, err := service.trackToPlayView(track)
+	if err != nil {
+		t.Fatalf("Failed to convert minimal track: %v", err)
+	}
+
+	if playView.TrackName != "Minimal Track" {
+		t.Errorf("Expected track name 'Minimal Track', got %s", playView.TrackName)
+	}
+
+	if len(playView.Artists) != 1 || playView.Artists[0].ArtistName != "Minimal Artist" {
+		t.Errorf("Artist not set correctly")
+	}
+
+	// Optional fields should be nil for minimal track
+	if playView.Duration != nil {
+		t.Errorf("Expected duration to be nil for minimal track")
+	}
+
+	if playView.ReleaseName != nil {
+		t.Errorf("Expected release name to be nil for minimal track")
+	}
+}

--- a/service/spotify/spotify.go
+++ b/service/spotify/spotify.go
@@ -538,14 +538,17 @@ func (s *SpotifyService) FetchCurrentTrack(userID int64) (*models.Track, error) 
 			} `json:"external_urls"`
 			DurationMs int `json:"duration_ms"`
 		} `json:"item"`
-		ProgressMS int `json:"progress_ms"`
+		ProgressMS int  `json:"progress_ms"`
+		IsPlaying  bool `json:"is_playing"`
 	}
 
 	err = json.Unmarshal(bodyBytes, &response) // Use bodyBytes here
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal spotify response: %w", err)
 	}
-
+	if response.IsPlaying == false {
+		return nil, nil
+	}
 	var artists []models.Artist
 	for _, artist := range response.Item.Artists {
 		artists = append(artists, models.Artist{


### PR DESCRIPTION
Adds in a few changes to #12 along with the base changes in it 

- Grabs `is_playing` for spotify and if set to false returns nil now for get current track to help with setting the new status
- Grabs the last status from the repo for the swap on put. Tested with and without the record in the repo