### PR TITLE
Fix incorrect scan order in GetUserByLastFM

### DIFF
--- a/db/lfm.go
+++ b/db/lfm.go
@@ -48,7 +48,7 @@ func (db *DB) GetUserByLastFM(lastfmUsername string) (*models.User, error) {
 
 	user := &models.User{}
 	err := row.Scan(
-		&user.ID, &user.MostRecentAtProtoSessionID, &user.Username, &user.Email, &user.ATProtoDID,
+		&user.ID, &user.Username, &user.Email, &user.ATProtoDID, &user.MostRecentAtProtoSessionID,
 		&user.CreatedAt, &user.UpdatedAt, &user.LastFMUsername)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This fixes an issue where the fields of the `models.User` from `GetUserByLastFM` were being assigned to incorrect columns from the result.    In my case I had a null user email which would be assigned to `MostRecentAtProtoSessionID` and piper would crash when attempting to submit a lastfm track to the PDS:

```
piper-1  | panic: runtime error: invalid memory address or nil pointer dereference
piper-1  | [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xb07aed]
piper-1  | 
piper-1  | goroutine 109 [running]:
piper-1  | github.com/teal-fm/piper/service/lastfm.(*LastFMService).processTracks(0xc0004c2800, {0xf6c960, 0x15d6f20}, {0xc000013e30, 0x7}, {0xc0001ac588, 0x6, 0xc0004c2900?})
piper-1  |      /app/service/lastfm/lastfm.go:395 +0x190d
piper-1  | github.com/teal-fm/piper/service/lastfm.(*LastFMService).fetchAllUserTracks.func1({0xc000013e30, 0x7})
piper-1  |      /app/service/lastfm/lastfm.go:246 +0x14d
piper-1  | created by github.com/teal-fm/piper/service/lastfm.(*LastFMService).fetchAllUserTracks in goroutine 66
piper-1  |      /app/service/lastfm/lastfm.go:223 +0x146
piper-1 exited with code 2
```