### PR TITLE
fix: filter out tracks without artists (podcasts, audiobooks, etc.)

### DIFF
--- a/service/spotify/spotify.go
+++ b/service/spotify/spotify.go
@@ -557,6 +557,11 @@ func (s *SpotifyService) FetchCurrentTrack(userID int64) (*models.Track, error) 
 		})
 	}
 
+	// ignore tracks with no artists (podcasts, audiobooks, etc)
+	if len(artists) == 0 {
+		return nil, nil
+	}
+
 	// assemble Track
 	track := &models.Track{
 		Name:           response.Item.Name,


### PR DESCRIPTION
haven't tested this but i don't see why it won't work