### PR TITLE
Adds the MIT license, same as the main repo

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 teal.fm
+Copyright (c) 2025 teal computing, LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
I propose a MIT license for this repo. Looks like it was forgotten to be added. Went with MIT since that's what the teal-fm/teal repo is

https://github.com/teal-fm/teal/blob/main/LICENSE

The following need to comment below to agree:
- [x] @kjloveless 
- [x] @fatfingers23 
- [x] @espeon 
- [x] @RoootTheFox 
- [x] @willgorman 