### PR TITLE
feat: add plyr.fm integration as music source

### DIFF
--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -28,6 +28,8 @@ func (app *application) routes() http.Handler {
 	mux.HandleFunc("/api-keys", session.WithAuth(app.apiKeyService.HandleAPIKeyManagement(app.database, app.pages), app.sessionManager))
 	mux.HandleFunc("/link-lastfm", session.WithAuth(handleLinkLastfmForm(app.database, app.pages), app.sessionManager)) // GET form
 	mux.HandleFunc("/link-lastfm/submit", session.WithAuth(handleLinkLastfmSubmit(app.database), app.sessionManager))   // POST submit - Changed route slightly
+	mux.HandleFunc("/link-plyrfm", session.WithAuth(handleLinkPlyrfmForm(app.database, app.pages), app.sessionManager)) // GET form + POST submit
+	mux.HandleFunc("/link-plyrfm/submit", session.WithAuth(handleLinkPlyrfmSubmit(app.database), app.sessionManager))   // POST submit
 	mux.HandleFunc("/logout", app.oauthManager.HandleLogout("atproto"))
 	mux.HandleFunc("/debug/", session.WithAuth(app.sessionManager.HandleDebug, app.sessionManager))
 
@@ -35,6 +37,9 @@ func (app *application) routes() http.Handler {
 	mux.HandleFunc("/api/v1/lastfm", session.WithAPIAuth(apiGetLastfmUserHandler(app.database), app.sessionManager))
 	mux.HandleFunc("/api/v1/lastfm/set", session.WithAPIAuth(apiLinkLastfmHandler(app.database), app.sessionManager))
 	mux.HandleFunc("/api/v1/lastfm/unset", session.WithAPIAuth(apiUnlinkLastfmHandler(app.database), app.sessionManager))
+	mux.HandleFunc("/api/v1/plyrfm", session.WithAPIAuth(apiGetPlyrfmHandler(app.database), app.sessionManager))
+	mux.HandleFunc("/api/v1/plyrfm/set", session.WithAPIAuth(apiLinkPlyrfmHandler(app.database), app.sessionManager))
+	mux.HandleFunc("/api/v1/plyrfm/unset", session.WithAPIAuth(apiUnlinkPlyrfmHandler(app.database), app.sessionManager))
 	mux.HandleFunc("/api/v1/current-track", session.WithAPIAuth(apiCurrentTrack(app.spotifyService), app.sessionManager)) // Spotify Current
 	mux.HandleFunc("/api/v1/history", session.WithAPIAuth(apiTrackHistory(app.spotifyService), app.sessionManager))       // Spotify History
 	mux.HandleFunc("/api/v1/musicbrainz/search", apiMusicBrainzSearch(app.mbService))                                     // MusicBrainz (public?)

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,10 @@ func Load() {
 	viper.SetDefault("tracker.interval", 30)
 	viper.SetDefault("db.path", "./data/piper.db")
 
+	// plyr.fm defaults
+	viper.SetDefault("plyrfm.api_url", "https://api.plyr.fm")
+	viper.SetDefault("plyrfm.interval_seconds", 30)
+
 	// server metadata
 	viper.SetDefault("server.root_url", "http://localhost:8080")
 	viper.SetDefault("atproto.metadata_url", "http://localhost:8080/metadata")

--- a/db/db.go
+++ b/db/db.go
@@ -138,6 +138,12 @@ func (db *DB) Initialize() error {
 		return err
 	}
 
+	// Add plyrfm_handle column for plyr.fm integration
+	_, err = db.Exec(`ALTER TABLE users ADD COLUMN plyrfm_handle TEXT`)
+	if err != nil && err.Error() != "duplicate column name: plyrfm_handle" {
+		return err
+	}
+
 	return nil
 }
 

--- a/db/plyrfm.go
+++ b/db/plyrfm.go
@@ -1,0 +1,59 @@
+package db
+
+import (
+	"github.com/teal-fm/piper/models"
+)
+
+func (db *DB) AddPlyrFMHandle(userID int64, handle string) error {
+	_, err := db.Exec(`
+    UPDATE users
+    SET plyrfm_handle = ?
+    WHERE id = ?`, handle, userID)
+
+	return err
+}
+
+func (db *DB) GetAllUsersWithPlyrFM() ([]*models.User, error) {
+	rows, err := db.Query(`
+    SELECT id, username, email, atproto_did, most_recent_at_session_id, plyrfm_handle
+    FROM users
+    WHERE plyrfm_handle IS NOT NULL
+    ORDER BY id`)
+
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var users []*models.User
+
+	for rows.Next() {
+		user := &models.User{}
+		err := rows.Scan(
+			&user.ID, &user.Username, &user.Email, &user.ATProtoDID,
+			&user.MostRecentAtProtoSessionID, &user.PlyrFMHandle)
+		if err != nil {
+			return nil, err
+		}
+		users = append(users, user)
+	}
+
+	return users, nil
+}
+
+func (db *DB) GetUserByPlyrFMHandle(handle string) (*models.User, error) {
+	row := db.QueryRow(`
+    SELECT id, username, email, atproto_did, most_recent_at_session_id, created_at, updated_at, plyrfm_handle
+    FROM users
+    WHERE plyrfm_handle = ?`, handle)
+
+	user := &models.User{}
+	err := row.Scan(
+		&user.ID, &user.Username, &user.Email, &user.ATProtoDID, &user.MostRecentAtProtoSessionID,
+		&user.CreatedAt, &user.UpdatedAt, &user.PlyrFMHandle)
+	if err != nil {
+		return nil, err
+	}
+
+	return user, nil
+}

--- a/models/user.go
+++ b/models/user.go
@@ -17,6 +17,9 @@ type User struct {
 	// lfm information
 	LastFMUsername *string
 
+	// plyr.fm information
+	PlyrFMHandle *string
+
 	// atp info
 	ATProtoDID *string
 	//This is meant to only be used by the automated music stamping service. If the user ever does an

--- a/pages/pages.go
+++ b/pages/pages.go
@@ -157,4 +157,5 @@ func (p *Pages) Execute(name string, w io.Writer, params any) error {
 type NavBar struct {
 	IsLoggedIn     bool
 	LastFMUsername string
+	PlyrFMHandle   string
 }

--- a/pages/templates/home.gohtml
+++ b/pages/templates/home.gohtml
@@ -1,19 +1,20 @@
 
 {{ define "content" }}
 
-    <h1 class="text-[#1DB954]">Piper - Multi-User Spotify & Last.fm Tracker via ATProto</h1>
+    <h1 class="text-[#1DB954]">Piper - Multi-User Spotify, Last.fm & plyr.fm Tracker via ATProto</h1>
     {{ template "components/navBar" .NavBar }}
 
 
     <div class="border border-gray-300 rounded-lg p-5 mb-5">
         <h2 class="text-xl font-semibold mb-2">Welcome to Piper</h2>
-        <p class="mb-3">Piper is a multi-user application that records what you're listening to on Spotify and Last.fm, saving your listening history.</p>
+        <p class="mb-3">Piper is a multi-user application that records what you're listening to on Spotify, Last.fm, and plyr.fm, saving your listening history.</p>
 
     {{if .NavBar.IsLoggedIn}}
         <p class="mb-2">You're logged in!</p>
         <ul class="list-disc pl-5 mb-3">
             <li><a class="text-[#1DB954] font-bold" href="/login/spotify">Connect your Spotify account</a> to start tracking.</li>
             <li><a class="text-[#1DB954] font-bold" href="/link-lastfm">Link your Last.fm account</a> to track scrobbles.</li>
+            <li><a class="text-[#6366f1] font-bold" href="/link-plyrfm">Link your plyr.fm account</a> to track what you're playing.</li>
         </ul>
         <p class="mb-2">Once connected, you can check out your:</p>
         <ul class="list-disc pl-5 mb-3">
@@ -29,6 +30,12 @@
             <p class='italic text-gray-600'>Last.fm Username: {{ .NavBar.LastFMUsername }}</p>
         {{else }}
             <p class='italic text-gray-600'>Last.fm account not linked.</p>
+        {{end}}
+
+        {{ if .NavBar.PlyrFMHandle }}
+            <p class='italic text-gray-600'>plyr.fm Handle: {{ .NavBar.PlyrFMHandle }}</p>
+        {{else }}
+            <p class='italic text-gray-600'>plyr.fm account not linked.</p>
         {{end}}
 
 

--- a/pages/templates/plyrFMForm.gohtml
+++ b/pages/templates/plyrFMForm.gohtml
@@ -1,0 +1,14 @@
+{{ define "content" }}
+    {{ template "components/navBar" .NavBar }}
+
+    <div class="max-w-[600px] mx-auto my-5 p-5 border border-gray-300 rounded-lg">
+        <h2 class="text-xl font-semibold mb-2">Link Your plyr.fm Account</h2>
+        <p class="mb-3">Enter your plyr.fm handle to track what you're listening to.</p>
+        <form class="space-y-2" method="post" action="/link-plyrfm">
+            <label class="block" for="plyrfm_handle">plyr.fm Handle:</label>
+            <input class="block w-[95%] p-2 border border-gray-300 rounded" type="text" id="plyrfm_handle" name="plyrfm_handle" value="{{.CurrentHandle}}" placeholder="your-handle" required>
+            <input class="bg-[#6366f1] text-white px-4 py-2.5 rounded cursor-pointer hover:opacity-90" type="submit" value="Save Handle">
+        </form>
+    </div>
+
+{{ end }}

--- a/service/plyrfm/plyrfm.go
+++ b/service/plyrfm/plyrfm.go
@@ -1,0 +1,335 @@
+package plyrfm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/teal-fm/piper/db"
+	"github.com/teal-fm/piper/models"
+	atprotoauth "github.com/teal-fm/piper/oauth/atproto"
+	atprotoservice "github.com/teal-fm/piper/service/atproto"
+	"github.com/teal-fm/piper/service/musicbrainz"
+)
+
+const (
+	// plyr.fm API base URL - configurable via env
+	defaultAPIBaseURL = "https://api.plyr.fm"
+)
+
+// NowPlayingResponse matches the response from plyr.fm's /now-playing/by-handle endpoint
+type NowPlayingResponse struct {
+	TrackName      string  `json:"track_name"`
+	ArtistName     string  `json:"artist_name"`
+	AlbumName      *string `json:"album_name"`
+	DurationMs     int64   `json:"duration_ms"`
+	ProgressMs     int64   `json:"progress_ms"`
+	IsPlaying      bool    `json:"is_playing"`
+	TrackID        int64   `json:"track_id"`
+	FileID         string  `json:"file_id"`
+	TrackURL       string  `json:"track_url"`
+	ImageURL       *string `json:"image_url"`
+	ServiceBaseURL string  `json:"service_base_url"`
+}
+
+// trackState holds the last seen track and whether it's been stamped
+type trackState struct {
+	track      *NowPlayingResponse
+	hasStamped bool
+}
+
+type PlyrFMService struct {
+	db                 *db.DB
+	httpClient         *http.Client
+	apiBaseURL         string
+	musicBrainzService *musicbrainz.MusicBrainzService
+	atprotoService     *atprotoauth.ATprotoAuthService
+	playingNowService  interface {
+		PublishPlayingNow(ctx context.Context, userID int64, track *models.Track) error
+		ClearPlayingNow(ctx context.Context, userID int64) error
+	}
+	// track last seen state per user to detect changes
+	lastSeenTracks map[string]*trackState
+	mu             sync.Mutex
+	logger         *log.Logger
+}
+
+func NewPlyrFMService(
+	database *db.DB,
+	apiBaseURL string,
+	musicBrainzService *musicbrainz.MusicBrainzService,
+	atprotoService *atprotoauth.ATprotoAuthService,
+	playingNowService interface {
+		PublishPlayingNow(ctx context.Context, userID int64, track *models.Track) error
+		ClearPlayingNow(ctx context.Context, userID int64) error
+	},
+) *PlyrFMService {
+	logger := log.New(os.Stdout, "plyrfm: ", log.LstdFlags|log.Lmsgprefix)
+
+	if apiBaseURL == "" {
+		apiBaseURL = defaultAPIBaseURL
+	}
+
+	return &PlyrFMService{
+		db: database,
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+		apiBaseURL:         apiBaseURL,
+		musicBrainzService: musicBrainzService,
+		atprotoService:     atprotoService,
+		playingNowService:  playingNowService,
+		lastSeenTracks:     make(map[string]*trackState),
+		logger:             logger,
+	}
+}
+
+// GetNowPlaying fetches the current playing track for a plyr.fm handle
+func (s *PlyrFMService) GetNowPlaying(ctx context.Context, handle string) (*NowPlayingResponse, error) {
+	url := fmt.Sprintf("%s/now-playing/by-handle/%s", s.apiBaseURL, handle)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch now playing for %s: %w", handle, err)
+	}
+	defer resp.Body.Close()
+
+	// 204 means nothing playing
+	if resp.StatusCode == http.StatusNoContent {
+		return nil, nil
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("plyr.fm API error for %s: status %d, body: %s", handle, resp.StatusCode, string(body))
+	}
+
+	var nowPlaying NowPlayingResponse
+	if err := json.NewDecoder(resp.Body).Decode(&nowPlaying); err != nil {
+		return nil, fmt.Errorf("failed to decode response for %s: %w", handle, err)
+	}
+
+	return &nowPlaying, nil
+}
+
+// convertToModelsTrack converts plyr.fm response to piper's Track model
+func (s *PlyrFMService) convertToModelsTrack(np *NowPlayingResponse) *models.Track {
+	artists := []models.Artist{
+		{
+			Name: np.ArtistName,
+		},
+	}
+
+	album := ""
+	if np.AlbumName != nil {
+		album = *np.AlbumName
+	}
+
+	return &models.Track{
+		Name:           np.TrackName,
+		Artist:         artists,
+		Album:          album,
+		URL:            np.TrackURL,
+		DurationMs:     np.DurationMs,
+		ProgressMs:     np.ProgressMs,
+		ServiceBaseUrl: "plyr.fm",
+		Timestamp:      time.Now().UTC(),
+		HasStamped:     false,
+	}
+}
+
+// isNewTrack checks if the current track is different from last seen
+func (s *PlyrFMService) isNewTrack(handle string, current *NowPlayingResponse) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state := s.lastSeenTracks[handle]
+	if state == nil || state.track == nil {
+		return true
+	}
+
+	// compare by track ID (most reliable)
+	return state.track.TrackID != current.TrackID
+}
+
+// hasBeenStamped checks if the current track has already been stamped
+func (s *PlyrFMService) hasBeenStamped(handle string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state := s.lastSeenTracks[handle]
+	if state == nil {
+		return false
+	}
+	return state.hasStamped
+}
+
+// markAsStamped marks the current track as stamped
+func (s *PlyrFMService) markAsStamped(handle string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if state := s.lastSeenTracks[handle]; state != nil {
+		state.hasStamped = true
+	}
+}
+
+// updateLastSeen updates the last seen track for a handle (resets stamped status for new tracks)
+func (s *PlyrFMService) updateLastSeen(handle string, track *NowPlayingResponse, isNew bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if isNew {
+		// new track - reset stamped status
+		s.lastSeenTracks[handle] = &trackState{track: track, hasStamped: false}
+	} else if state := s.lastSeenTracks[handle]; state != nil {
+		// same track - just update the track data (progress, etc)
+		state.track = track
+	}
+}
+
+// clearLastSeen clears the last seen track when nothing is playing
+func (s *PlyrFMService) clearLastSeen(handle string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.lastSeenTracks, handle)
+}
+
+// processUser fetches and processes now-playing for a single user
+func (s *PlyrFMService) processUser(ctx context.Context, user *models.User, handle string) error {
+	nowPlaying, err := s.GetNowPlaying(ctx, handle)
+	if err != nil {
+		return fmt.Errorf("error fetching now playing: %w", err)
+	}
+
+	// nothing playing - clear state
+	if nowPlaying == nil || !nowPlaying.IsPlaying {
+		s.clearLastSeen(handle)
+		if s.playingNowService != nil {
+			if err := s.playingNowService.ClearPlayingNow(ctx, user.ID); err != nil {
+				s.logger.Printf("error clearing playing now for user %s: %v", handle, err)
+			}
+		}
+		return nil
+	}
+
+	// check if this is a new track
+	isNew := s.isNewTrack(handle, nowPlaying)
+	s.updateLastSeen(handle, nowPlaying, isNew)
+
+	// convert to piper track format
+	track := s.convertToModelsTrack(nowPlaying)
+
+	// publish playing now status
+	if s.playingNowService != nil {
+		if err := s.playingNowService.PublishPlayingNow(ctx, user.ID, track); err != nil {
+			s.logger.Printf("error publishing playing now for user %s: %v", handle, err)
+		}
+	}
+
+	// if new track, log and save to DB
+	if isNew {
+		s.logger.Printf("user %s is listening to: %s by %s", handle, track.Name, track.Artist[0].Name)
+
+		// save track to DB
+		if _, err := s.db.SaveTrack(user.ID, track); err != nil {
+			s.logger.Printf("error saving track for user %s: %v", handle, err)
+		}
+	}
+
+	// check stamping threshold: >50% played OR >30s played (standard scrobble rules)
+	meetsThreshold := nowPlaying.ProgressMs > nowPlaying.DurationMs/2 || nowPlaying.ProgressMs > 30000
+	alreadyStamped := s.hasBeenStamped(handle)
+
+	if meetsThreshold && !alreadyStamped {
+		s.markAsStamped(handle)
+		s.logger.Printf("user %s stamped track: %s by %s", handle, track.Name, track.Artist[0].Name)
+
+		// submit to ATProto PDS if configured
+		if user.ATProtoDID != nil && *user.ATProtoDID != "" && user.MostRecentAtProtoSessionID != nil {
+			// optionally hydrate with MusicBrainz data
+			trackToSubmit := track
+			if s.musicBrainzService != nil {
+				hydratedTrack, err := musicbrainz.HydrateTrack(s.musicBrainzService, *track)
+				if err != nil {
+					s.logger.Printf("error hydrating track: %v, using original", err)
+				} else {
+					trackToSubmit = hydratedTrack
+				}
+			}
+
+			if err := s.SubmitTrackToPDS(*user.ATProtoDID, *user.MostRecentAtProtoSessionID, trackToSubmit, ctx); err != nil {
+				s.logger.Printf("error submitting track to PDS for user %s: %v", handle, err)
+			} else {
+				s.logger.Printf("submitted track to PDS for user %s", handle)
+			}
+		}
+	}
+
+	return nil
+}
+
+// SubmitTrackToPDS submits a track to the user's ATProto PDS
+func (s *PlyrFMService) SubmitTrackToPDS(did string, sessionID string, track *models.Track, ctx context.Context) error {
+	return atprotoservice.SubmitPlayToPDS(ctx, did, sessionID, track, s.atprotoService)
+}
+
+// StartListeningTracker starts the periodic tracker for plyr.fm users
+func (s *PlyrFMService) StartListeningTracker(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+
+	go func() {
+		// initial fetch
+		s.fetchAllUserTracks(context.Background())
+
+		for range ticker.C {
+			s.logger.Println("fetching plyr.fm tracks...")
+			s.fetchAllUserTracks(context.Background())
+			s.logger.Println("finished plyr.fm fetch cycle")
+		}
+	}()
+
+	s.logger.Printf("plyr.fm listening tracker started with interval %v", interval)
+}
+
+// fetchAllUserTracks fetches tracks for all users with plyr.fm handles configured
+func (s *PlyrFMService) fetchAllUserTracks(ctx context.Context) {
+	users, err := s.db.GetAllUsersWithPlyrFM()
+	if err != nil {
+		s.logger.Printf("error loading plyr.fm users: %v", err)
+		return
+	}
+
+	if len(users) == 0 {
+		s.logger.Println("no plyr.fm users configured")
+		return
+	}
+
+	s.logger.Printf("processing %d plyr.fm users", len(users))
+
+	for _, user := range users {
+		if ctx.Err() != nil {
+			s.logger.Println("context cancelled, stopping fetch")
+			break
+		}
+
+		if user.PlyrFMHandle == nil || *user.PlyrFMHandle == "" {
+			continue
+		}
+
+		if err := s.processUser(ctx, user, *user.PlyrFMHandle); err != nil {
+			s.logger.Printf("error processing user %s: %v", *user.PlyrFMHandle, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Adds [plyr.fm](https://plyr.fm) as a new music source alongside Spotify and Last.fm
- plyr.fm is an ATProto-native music streaming service
- Polls the now-playing API to track listening activity and publish to ATProto PDS

## Changes
- Add `PlyrFMService` that polls plyr.fm's `/now-playing/by-handle/{handle}` endpoint
- Add database support for storing plyr.fm handles per user
- Add web UI for linking plyr.fm accounts (`/link-plyrfm`)
- Add API endpoints for programmatic plyr.fm handle management
- Publish playing-now status and stamp tracks to ATProto PDS

## Test plan
- [x] Tested locally with ngrok tunnel
- [x] Verified track detection from plyr.fm API
- [x] Verified playing-now status publishes to PDS
- [x] Verified no duplicate tracks on repeated polling
- [ ] Test with multiple users

🤖 Generated with [Claude Code](https://claude.com/claude-code)