### PR TITLE
Remove unused KeyPrefix in API Key template

### DIFF
--- a/pages/templates/apiKeys.gohtml
+++ b/pages/templates/apiKeys.gohtml
@@ -34,7 +34,6 @@
             <thead>
             <tr class="text-left border-b border-gray-300">
                 <th class="p-2">Name</th>
-                <th class="p-2">Prefix</th>
                 <th class="p-2">Created</th>
                 <th class="p-2">Expires</th>
                 <th class="p-2">Actions</th>
@@ -44,7 +43,6 @@
             {{range .Keys}}
                 <tr class="border-b border-gray-200">
                     <td class="p-2">{{.Name}}</td>
-                    <td class="p-2">{{.KeyPrefix}}</td> <!-- Added KeyPrefix for better identification -->
                     <td class="p-2">{{formatTime .CreatedAt}}</td>
                     <td class="p-2">{{formatTime .ExpiresAt}}</td>
                     <td class="p-2">


### PR DESCRIPTION
The API Keys page is failing to render due to the `KeyPrefix` field used in the template not existing on the `ApiKey` object. I could only find one other reference to `KeyPrefix` in the repo and it was in a comment, so I assume this was a planned addition or maybe Claude thought it was cool. Removing the line fixes the rendering issue.

I've never written a line of Go in my life, but I don't think this should have broken anything.

### Screenshots

<details>
<summary>Before (current latest container)</summary>
<img width="1231" height="873" alt="Screenshot From 2025-12-24 16-01-29" src="https://github.com/user-attachments/assets/7e18c47f-4fc6-4a97-8a5b-a6e79389c888" />
</details>

<details>
<summary>After</summary>
<img width="1266" height="1266" alt="Screenshot From 2025-12-24 16-41-53" src="https://github.com/user-attachments/assets/2aaf27da-a128-4f86-b823-5da7eee5cc32" />
</details>