### PR TITLE
fix: Fetch all Last.fm scrobbles since last fetch

### DIFF
--- a/service/lastfm/lastfm.go
+++ b/service/lastfm/lastfm.go
@@ -358,7 +358,7 @@ func (l *Service) processTracks(ctx context.Context, username string, tracks []T
 
 	// find last non-now-playing track
 	var lastNonNowPlaying *Track
-	for i := 0; i <= len(tracks)-1; i++ {
+	for i := range tracks {
 		if tracks[i].Attr == nil || tracks[i].Attr.NowPlaying != "true" {
 			lastNonNowPlaying = &tracks[i]
 			break


### PR DESCRIPTION
Fix for #20 — rather than retrieving the last 5 tracks from Last.fm, retrieve all tracks since the user's `lastKnownTimestamp`, up to a limit of 200 (Last.fm's upper limit is for `user.getrecenttracks`).

If no `lastKnownTimestamp`, then just fetch the most recent 5 tracks as before.

Also includes a little tweak to the way that the `lastKnownTimestamp` is calculated — see comment on the code below.