### PR TITLE
Make all polling services optional

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -57,18 +57,4 @@ func Load() {
 	} else {
 		log.Println("Using config file:", viper.ConfigFileUsed())
 	}
-
-	// check for required settings
-	requiredVars := []string{"spotify.client_id", "spotify.client_secret"}
-	var missingVars []string
-
-	for _, v := range requiredVars {
-		if !viper.IsSet(v) {
-			missingVars = append(missingVars, v)
-		}
-	}
-
-	if len(missingVars) > 0 {
-		log.Fatalf("Required configuration variables not set: %s", strings.Join(missingVars, ", "))
-	}
 }


### PR DESCRIPTION
Piper is currently requiring Spotify environment variables be set for it to start even if Spotify is never used. It also always enables the Last.fm endpoint even if no API key is provided. There's no reason to start up a service if it isn't going to work or ever be used.

The recent Apple Music service was setup to not enable itself if the required env vars aren't provided. This PR mirrors that logic and applies it to all other services. Mainly, this just impacts Last.fm and Spotify, both of which now require their env vars to be set for the service to enable.

All services also now log when they're enabled or disabled.

---

FYI - I cannot test that Last.fm works fine after this, but I don't think it should break anything as it's just rearranging the existing logic. Also, the Last.fm user add page (/link-lastfm) still seems to work fine, but I don't think it interacts with the service, so that's probably expected.

I use Spotify and can confirm that it enables and disables just fine.