### PR TITLE
Remove alpha from Teal lexicon namespace

### DIFF
--- a/api/teal/actordefs.go
+++ b/api/teal/actordefs.go
@@ -2,14 +2,14 @@
 
 package teal
 
-// schema: fm.teal.alpha.actor.defs
+// schema: fm.teal.actor.defs
 
 import (
 	appbskytypes "github.com/bluesky-social/indigo/api/bsky"
 )
 
-// AlphaActorDefs_MiniProfileView is a "miniProfileView" in the fm.teal.alpha.actor.defs schema.
-type AlphaActorDefs_MiniProfileView struct {
+// ActorDefs_MiniProfileView is a "miniProfileView" in the fm.teal.actor.defs schema.
+type ActorDefs_MiniProfileView struct {
 	// avatar: IPLD of the avatar
 	Avatar *string `json:"avatar,omitempty" cborgen:"avatar,omitempty"`
 	// did: The decentralized identifier of the actor
@@ -18,8 +18,8 @@ type AlphaActorDefs_MiniProfileView struct {
 	Handle      *string `json:"handle,omitempty" cborgen:"handle,omitempty"`
 }
 
-// AlphaActorDefs_ProfileView is a "profileView" in the fm.teal.alpha.actor.defs schema.
-type AlphaActorDefs_ProfileView struct {
+// ActorDefs_ProfileView is a "profileView" in the fm.teal.actor.defs schema.
+type ActorDefs_ProfileView struct {
 	// avatar: IPLD of the avatar
 	Avatar *string `json:"avatar,omitempty" cborgen:"avatar,omitempty"`
 	// banner: IPLD of the banner image
@@ -33,17 +33,17 @@ type AlphaActorDefs_ProfileView struct {
 	Did         *string `json:"did,omitempty" cborgen:"did,omitempty"`
 	DisplayName *string `json:"displayName,omitempty" cborgen:"displayName,omitempty"`
 	// featuredItem: The user's most recent item featured on their profile.
-	FeaturedItem *AlphaActorProfile_FeaturedItem `json:"featuredItem,omitempty" cborgen:"featuredItem,omitempty"`
-	Status       *AlphaActorDefs_StatusView      `json:"status,omitempty" cborgen:"status,omitempty"`
+	FeaturedItem *ActorProfile_FeaturedItem `json:"featuredItem,omitempty" cborgen:"featuredItem,omitempty"`
+	Status       *ActorDefs_StatusView      `json:"status,omitempty" cborgen:"status,omitempty"`
 }
 
-// AlphaActorDefs_StatusView is a "statusView" in the fm.teal.alpha.actor.defs schema.
+// ActorDefs_StatusView is a "statusView" in the fm.teal.actor.defs schema.
 //
 // A declaration of the status of the actor.
-type AlphaActorDefs_StatusView struct {
+type ActorDefs_StatusView struct {
 	// expiry: The unix timestamp of the expiry time of the item. If unavailable, default to 10 minutes past the start time.
-	Expiry *string                 `json:"expiry,omitempty" cborgen:"expiry,omitempty"`
-	Item   *AlphaFeedDefs_PlayView `json:"item,omitempty" cborgen:"item,omitempty"`
+	Expiry *string            `json:"expiry,omitempty" cborgen:"expiry,omitempty"`
+	Item   *FeedDefs_PlayView `json:"item,omitempty" cborgen:"item,omitempty"`
 	// time: The unix timestamp of when the item was recorded
 	Time *string `json:"time,omitempty" cborgen:"time,omitempty"`
 }

--- a/api/teal/actorgetProfile.go
+++ b/api/teal/actorgetProfile.go
@@ -2,7 +2,7 @@
 
 package teal
 
-// schema: fm.teal.alpha.actor.getProfile
+// schema: fm.teal.actor.getProfile
 
 import (
 	"context"
@@ -10,20 +10,20 @@ import (
 	"github.com/bluesky-social/indigo/lex/util"
 )
 
-// AlphaActorGetProfile_Output is the output of a fm.teal.alpha.actor.getProfile call.
-type AlphaActorGetProfile_Output struct {
-	Actor *AlphaActorDefs_ProfileView `json:"actor" cborgen:"actor"`
+// ActorGetProfile_Output is the output of a fm.teal.actor.getProfile call.
+type ActorGetProfile_Output struct {
+	Actor *ActorDefs_ProfileView `json:"actor" cborgen:"actor"`
 }
 
-// AlphaActorGetProfile calls the XRPC method "fm.teal.alpha.actor.getProfile".
+// ActorGetProfile calls the XRPC method "fm.teal.actor.getProfile".
 //
 // actor: The author's DID
-func AlphaActorGetProfile(ctx context.Context, c util.LexClient, actor string) (*AlphaActorGetProfile_Output, error) {
-	var out AlphaActorGetProfile_Output
+func ActorGetProfile(ctx context.Context, c util.LexClient, actor string) (*ActorGetProfile_Output, error) {
+	var out ActorGetProfile_Output
 
 	params := map[string]interface{}{}
 	params["actor"] = actor
-	if err := c.LexDo(ctx, util.Query, "", "fm.teal.alpha.actor.getProfile", params, nil, &out); err != nil {
+	if err := c.LexDo(ctx, util.Query, "", "fm.teal.actor.getProfile", params, nil, &out); err != nil {
 		return nil, err
 	}
 

--- a/api/teal/actorgetProfiles.go
+++ b/api/teal/actorgetProfiles.go
@@ -2,7 +2,7 @@
 
 package teal
 
-// schema: fm.teal.alpha.actor.getProfiles
+// schema: fm.teal.actor.getProfiles
 
 import (
 	"context"
@@ -10,20 +10,20 @@ import (
 	"github.com/bluesky-social/indigo/lex/util"
 )
 
-// AlphaActorGetProfiles_Output is the output of a fm.teal.alpha.actor.getProfiles call.
-type AlphaActorGetProfiles_Output struct {
-	Actors []*AlphaActorDefs_MiniProfileView `json:"actors" cborgen:"actors"`
+// ActorGetProfiles_Output is the output of a fm.teal.actor.getProfiles call.
+type ActorGetProfiles_Output struct {
+	Actors []*ActorDefs_MiniProfileView `json:"actors" cborgen:"actors"`
 }
 
-// AlphaActorGetProfiles calls the XRPC method "fm.teal.alpha.actor.getProfiles".
+// ActorGetProfiles calls the XRPC method "fm.teal.actor.getProfiles".
 //
 // actors: Array of actor DIDs
-func AlphaActorGetProfiles(ctx context.Context, c util.LexClient, actors []string) (*AlphaActorGetProfiles_Output, error) {
-	var out AlphaActorGetProfiles_Output
+func ActorGetProfiles(ctx context.Context, c util.LexClient, actors []string) (*ActorGetProfiles_Output, error) {
+	var out ActorGetProfiles_Output
 
 	params := map[string]interface{}{}
 	params["actors"] = actors
-	if err := c.LexDo(ctx, util.Query, "", "fm.teal.alpha.actor.getProfiles", params, nil, &out); err != nil {
+	if err := c.LexDo(ctx, util.Query, "", "fm.teal.actor.getProfiles", params, nil, &out); err != nil {
 		return nil, err
 	}
 

--- a/api/teal/actorprofile.go
+++ b/api/teal/actorprofile.go
@@ -2,16 +2,16 @@
 
 package teal
 
-// schema: fm.teal.alpha.actor.profile
+// schema: fm.teal.actor.profile
 
 import (
 	appbskytypes "github.com/bluesky-social/indigo/api/bsky"
 	"github.com/bluesky-social/indigo/lex/util"
 )
 
-// RECORDTYPE: AlphaActorProfile
-type AlphaActorProfile struct {
-	LexiconTypeID string `json:"$type,const=fm.teal.alpha.actor.profile" cborgen:"$type,const=fm.teal.alpha.actor.profile"`
+// RECORDTYPE: ActorProfile
+type ActorProfile struct {
+	LexiconTypeID string `json:"$type,const=fm.teal.actor.profile" cborgen:"$type,const=fm.teal.actor.profile"`
 	// avatar: Small image to be displayed next to posts from account. AKA, 'profile picture'
 	Avatar *util.LexBlob `json:"avatar,omitempty" cborgen:"avatar,omitempty"`
 	// banner: Larger horizontal image to display behind profile view.
@@ -23,11 +23,11 @@ type AlphaActorProfile struct {
 	DescriptionFacets []*appbskytypes.RichtextFacet `json:"descriptionFacets,omitempty" cborgen:"descriptionFacets,omitempty"`
 	DisplayName       *string                       `json:"displayName,omitempty" cborgen:"displayName,omitempty"`
 	// featuredItem: The user's most recent item featured on their profile.
-	FeaturedItem *AlphaActorProfile_FeaturedItem `json:"featuredItem,omitempty" cborgen:"featuredItem,omitempty"`
+	FeaturedItem *ActorProfile_FeaturedItem `json:"featuredItem,omitempty" cborgen:"featuredItem,omitempty"`
 }
 
-// AlphaActorProfile_FeaturedItem is a "featuredItem" in the fm.teal.alpha.actor.profile schema.
-type AlphaActorProfile_FeaturedItem struct {
+// ActorProfile_FeaturedItem is a "featuredItem" in the fm.teal.actor.profile schema.
+type ActorProfile_FeaturedItem struct {
 	// mbid: The MusicBrainz ID URI of the item, formatted as mbid:<uuid>
 	Mbid string `json:"mbid" cborgen:"mbid"`
 	// type: The type of the item. Must be a valid Musicbrainz type, e.g. album, track, recording, etc.
@@ -35,5 +35,5 @@ type AlphaActorProfile_FeaturedItem struct {
 }
 
 func init() {
-	util.RegisterType("fm.teal.alpha.actor.profile", &AlphaActorProfile{})
+	util.RegisterType("fm.teal.actor.profile", &ActorProfile{})
 }

--- a/api/teal/actorsearchActors.go
+++ b/api/teal/actorsearchActors.go
@@ -2,7 +2,7 @@
 
 package teal
 
-// schema: fm.teal.alpha.actor.searchActors
+// schema: fm.teal.actor.searchActors
 
 import (
 	"context"
@@ -10,20 +10,20 @@ import (
 	"github.com/bluesky-social/indigo/lex/util"
 )
 
-// AlphaActorSearchActors_Output is the output of a fm.teal.alpha.actor.searchActors call.
-type AlphaActorSearchActors_Output struct {
-	Actors []*AlphaActorDefs_MiniProfileView `json:"actors" cborgen:"actors"`
+// ActorSearchActors_Output is the output of a fm.teal.actor.searchActors call.
+type ActorSearchActors_Output struct {
+	Actors []*ActorDefs_MiniProfileView `json:"actors" cborgen:"actors"`
 	// cursor: Cursor for pagination
 	Cursor *string `json:"cursor,omitempty" cborgen:"cursor,omitempty"`
 }
 
-// AlphaActorSearchActors calls the XRPC method "fm.teal.alpha.actor.searchActors".
+// ActorSearchActors calls the XRPC method "fm.teal.actor.searchActors".
 //
 // cursor: Cursor for pagination
 // limit: The maximum number of actors to return
 // q: The search query
-func AlphaActorSearchActors(ctx context.Context, c util.LexClient, cursor string, limit int64, q string) (*AlphaActorSearchActors_Output, error) {
-	var out AlphaActorSearchActors_Output
+func ActorSearchActors(ctx context.Context, c util.LexClient, cursor string, limit int64, q string) (*ActorSearchActors_Output, error) {
+	var out ActorSearchActors_Output
 
 	params := map[string]interface{}{}
 	if cursor != "" {
@@ -33,7 +33,7 @@ func AlphaActorSearchActors(ctx context.Context, c util.LexClient, cursor string
 		params["limit"] = limit
 	}
 	params["q"] = q
-	if err := c.LexDo(ctx, util.Query, "", "fm.teal.alpha.actor.searchActors", params, nil, &out); err != nil {
+	if err := c.LexDo(ctx, util.Query, "", "fm.teal.actor.searchActors", params, nil, &out); err != nil {
 		return nil, err
 	}
 

--- a/api/teal/actorstatus.go
+++ b/api/teal/actorstatus.go
@@ -4,18 +4,18 @@ package teal
 
 import "github.com/bluesky-social/indigo/lex/util"
 
-// schema: fm.teal.alpha.actor.status
+// schema: fm.teal.actor.status
 
-// RECORDTYPE: AlphaActorStatus
-type AlphaActorStatus struct {
-	LexiconTypeID string `json:"$type,const=fm.teal.alpha.actor.status" cborgen:"$type,const=fm.teal.alpha.actor.status"`
+// RECORDTYPE: ActorStatus
+type ActorStatus struct {
+	LexiconTypeID string `json:"$type,const=fm.teal.actor.status" cborgen:"$type,const=fm.teal.actor.status"`
 	// expiry: The RFC 3339 formatted time of the expiry time of the item. If unavailable, default to 10 minutes past the start time.
-	Expiry *string                 `json:"expiry,omitempty" cborgen:"expiry,omitempty"`
-	Item   *AlphaFeedDefs_PlayView `json:"item" cborgen:"item"`
+	Expiry *string            `json:"expiry,omitempty" cborgen:"expiry,omitempty"`
+	Item   *FeedDefs_PlayView `json:"item" cborgen:"item"`
 	// time: The RFC 3339 formatted time of when the item was recorded
 	Time string `json:"time" cborgen:"time"`
 }
 
 func init() {
-	util.RegisterType("fm.teal.alpha.actor.status", &AlphaActorStatus{})
+	util.RegisterType("fm.teal.actor.status", &ActorStatus{})
 }

--- a/api/teal/cbor_gen.go
+++ b/api/teal/cbor_gen.go
@@ -49,11 +49,11 @@ func (t *FeedPlay) MarshalCBOR(w io.Writer) error {
 		fieldCount--
 	}
 
-	if t.MusicServiceBaseDomain == nil {
+	if t.MusicServiceUri == nil {
 		fieldCount--
 	}
 
-	if t.OriginUrl == nil {
+	if t.OriginUri == nil {
 		fieldCount--
 	}
 
@@ -205,33 +205,33 @@ func (t *FeedPlay) MarshalCBOR(w io.Writer) error {
 
 	}
 
-	// t.OriginUrl (string) (string)
-	if t.OriginUrl != nil {
+	// t.OriginUri (string) (string)
+	if t.OriginUri != nil {
 
-		if len("originUrl") > 1000000 {
-			return xerrors.Errorf("Value in field \"originUrl\" was too long")
+		if len("originUri") > 1000000 {
+			return xerrors.Errorf("Value in field \"originUri\" was too long")
 		}
 
-		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("originUrl"))); err != nil {
+		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("originUri"))); err != nil {
 			return err
 		}
-		if _, err := cw.WriteString(string("originUrl")); err != nil {
+		if _, err := cw.WriteString(string("originUri")); err != nil {
 			return err
 		}
 
-		if t.OriginUrl == nil {
+		if t.OriginUri == nil {
 			if _, err := cw.Write(cbg.CborNull); err != nil {
 				return err
 			}
 		} else {
-			if len(*t.OriginUrl) > 1000000 {
-				return xerrors.Errorf("Value in field t.OriginUrl was too long")
+			if len(*t.OriginUri) > 1000000 {
+				return xerrors.Errorf("Value in field t.OriginUri was too long")
 			}
 
-			if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(*t.OriginUrl))); err != nil {
+			if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(*t.OriginUri))); err != nil {
 				return err
 			}
-			if _, err := cw.WriteString(string(*t.OriginUrl)); err != nil {
+			if _, err := cw.WriteString(string(*t.OriginUri)); err != nil {
 				return err
 			}
 		}
@@ -492,6 +492,38 @@ func (t *FeedPlay) MarshalCBOR(w io.Writer) error {
 		}
 	}
 
+	// t.MusicServiceUri (string) (string)
+	if t.MusicServiceUri != nil {
+
+		if len("musicServiceUri") > 1000000 {
+			return xerrors.Errorf("Value in field \"musicServiceUri\" was too long")
+		}
+
+		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("musicServiceUri"))); err != nil {
+			return err
+		}
+		if _, err := cw.WriteString(string("musicServiceUri")); err != nil {
+			return err
+		}
+
+		if t.MusicServiceUri == nil {
+			if _, err := cw.Write(cbg.CborNull); err != nil {
+				return err
+			}
+		} else {
+			if len(*t.MusicServiceUri) > 1000000 {
+				return xerrors.Errorf("Value in field t.MusicServiceUri was too long")
+			}
+
+			if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(*t.MusicServiceUri))); err != nil {
+				return err
+			}
+			if _, err := cw.WriteString(string(*t.MusicServiceUri)); err != nil {
+				return err
+			}
+		}
+	}
+
 	// t.TrackDiscriminant (string) (string)
 	if t.TrackDiscriminant != nil {
 
@@ -587,38 +619,6 @@ func (t *FeedPlay) MarshalCBOR(w io.Writer) error {
 			}
 		}
 	}
-
-	// t.MusicServiceBaseDomain (string) (string)
-	if t.MusicServiceBaseDomain != nil {
-
-		if len("musicServiceBaseDomain") > 1000000 {
-			return xerrors.Errorf("Value in field \"musicServiceBaseDomain\" was too long")
-		}
-
-		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("musicServiceBaseDomain"))); err != nil {
-			return err
-		}
-		if _, err := cw.WriteString(string("musicServiceBaseDomain")); err != nil {
-			return err
-		}
-
-		if t.MusicServiceBaseDomain == nil {
-			if _, err := cw.Write(cbg.CborNull); err != nil {
-				return err
-			}
-		} else {
-			if len(*t.MusicServiceBaseDomain) > 1000000 {
-				return xerrors.Errorf("Value in field t.MusicServiceBaseDomain was too long")
-			}
-
-			if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(*t.MusicServiceBaseDomain))); err != nil {
-				return err
-			}
-			if _, err := cw.WriteString(string(*t.MusicServiceBaseDomain)); err != nil {
-				return err
-			}
-		}
-	}
 	return nil
 }
 
@@ -647,7 +647,7 @@ func (t *FeedPlay) UnmarshalCBOR(r io.Reader) (err error) {
 
 	n := extra
 
-	nameBuf := make([]byte, 22)
+	nameBuf := make([]byte, 21)
 	for i := uint64(0); i < n; i++ {
 		nameLen, ok, err := cbg.ReadFullStringIntoBuf(cr, nameBuf, 1000000)
 		if err != nil {
@@ -780,8 +780,8 @@ func (t *FeedPlay) UnmarshalCBOR(r io.Reader) (err error) {
 					t.Duration = (*int64)(&extraI)
 				}
 			}
-			// t.OriginUrl (string) (string)
-		case "originUrl":
+			// t.OriginUri (string) (string)
+		case "originUri":
 
 			{
 				b, err := cr.ReadByte()
@@ -798,7 +798,7 @@ func (t *FeedPlay) UnmarshalCBOR(r io.Reader) (err error) {
 						return err
 					}
 
-					t.OriginUrl = (*string)(&sval)
+					t.OriginUri = (*string)(&sval)
 				}
 			}
 			// t.TrackMbId (string) (string)
@@ -997,6 +997,27 @@ func (t *FeedPlay) UnmarshalCBOR(r io.Reader) (err error) {
 					t.RecordingMbId = (*string)(&sval)
 				}
 			}
+			// t.MusicServiceUri (string) (string)
+		case "musicServiceUri":
+
+			{
+				b, err := cr.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := cr.UnreadByte(); err != nil {
+						return err
+					}
+
+					sval, err := cbg.ReadStringWithMax(cr, 1000000)
+					if err != nil {
+						return err
+					}
+
+					t.MusicServiceUri = (*string)(&sval)
+				}
+			}
 			// t.TrackDiscriminant (string) (string)
 		case "trackDiscriminant":
 
@@ -1058,27 +1079,6 @@ func (t *FeedPlay) UnmarshalCBOR(r io.Reader) (err error) {
 					}
 
 					t.SubmissionClientAgent = (*string)(&sval)
-				}
-			}
-			// t.MusicServiceBaseDomain (string) (string)
-		case "musicServiceBaseDomain":
-
-			{
-				b, err := cr.ReadByte()
-				if err != nil {
-					return err
-				}
-				if b != cbg.CborNull[0] {
-					if err := cr.UnreadByte(); err != nil {
-						return err
-					}
-
-					sval, err := cbg.ReadStringWithMax(cr, 1000000)
-					if err != nil {
-						return err
-					}
-
-					t.MusicServiceBaseDomain = (*string)(&sval)
 				}
 			}
 
@@ -1946,11 +1946,11 @@ func (t *FeedDefs_PlayView) MarshalCBOR(w io.Writer) error {
 		fieldCount--
 	}
 
-	if t.MusicServiceBaseDomain == nil {
+	if t.MusicServiceUri == nil {
 		fieldCount--
 	}
 
-	if t.OriginUrl == nil {
+	if t.OriginUri == nil {
 		fieldCount--
 	}
 
@@ -2072,33 +2072,33 @@ func (t *FeedDefs_PlayView) MarshalCBOR(w io.Writer) error {
 
 	}
 
-	// t.OriginUrl (string) (string)
-	if t.OriginUrl != nil {
+	// t.OriginUri (string) (string)
+	if t.OriginUri != nil {
 
-		if len("originUrl") > 1000000 {
-			return xerrors.Errorf("Value in field \"originUrl\" was too long")
+		if len("originUri") > 1000000 {
+			return xerrors.Errorf("Value in field \"originUri\" was too long")
 		}
 
-		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("originUrl"))); err != nil {
+		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("originUri"))); err != nil {
 			return err
 		}
-		if _, err := cw.WriteString(string("originUrl")); err != nil {
+		if _, err := cw.WriteString(string("originUri")); err != nil {
 			return err
 		}
 
-		if t.OriginUrl == nil {
+		if t.OriginUri == nil {
 			if _, err := cw.Write(cbg.CborNull); err != nil {
 				return err
 			}
 		} else {
-			if len(*t.OriginUrl) > 1000000 {
-				return xerrors.Errorf("Value in field t.OriginUrl was too long")
+			if len(*t.OriginUri) > 1000000 {
+				return xerrors.Errorf("Value in field t.OriginUri was too long")
 			}
 
-			if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(*t.OriginUrl))); err != nil {
+			if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(*t.OriginUri))); err != nil {
 				return err
 			}
-			if _, err := cw.WriteString(string(*t.OriginUrl)); err != nil {
+			if _, err := cw.WriteString(string(*t.OriginUri)); err != nil {
 				return err
 			}
 		}
@@ -2287,6 +2287,38 @@ func (t *FeedDefs_PlayView) MarshalCBOR(w io.Writer) error {
 		}
 	}
 
+	// t.MusicServiceUri (string) (string)
+	if t.MusicServiceUri != nil {
+
+		if len("musicServiceUri") > 1000000 {
+			return xerrors.Errorf("Value in field \"musicServiceUri\" was too long")
+		}
+
+		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("musicServiceUri"))); err != nil {
+			return err
+		}
+		if _, err := cw.WriteString(string("musicServiceUri")); err != nil {
+			return err
+		}
+
+		if t.MusicServiceUri == nil {
+			if _, err := cw.Write(cbg.CborNull); err != nil {
+				return err
+			}
+		} else {
+			if len(*t.MusicServiceUri) > 1000000 {
+				return xerrors.Errorf("Value in field t.MusicServiceUri was too long")
+			}
+
+			if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(*t.MusicServiceUri))); err != nil {
+				return err
+			}
+			if _, err := cw.WriteString(string(*t.MusicServiceUri)); err != nil {
+				return err
+			}
+		}
+	}
+
 	// t.SubmissionClientAgent (string) (string)
 	if t.SubmissionClientAgent != nil {
 
@@ -2314,38 +2346,6 @@ func (t *FeedDefs_PlayView) MarshalCBOR(w io.Writer) error {
 				return err
 			}
 			if _, err := cw.WriteString(string(*t.SubmissionClientAgent)); err != nil {
-				return err
-			}
-		}
-	}
-
-	// t.MusicServiceBaseDomain (string) (string)
-	if t.MusicServiceBaseDomain != nil {
-
-		if len("musicServiceBaseDomain") > 1000000 {
-			return xerrors.Errorf("Value in field \"musicServiceBaseDomain\" was too long")
-		}
-
-		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("musicServiceBaseDomain"))); err != nil {
-			return err
-		}
-		if _, err := cw.WriteString(string("musicServiceBaseDomain")); err != nil {
-			return err
-		}
-
-		if t.MusicServiceBaseDomain == nil {
-			if _, err := cw.Write(cbg.CborNull); err != nil {
-				return err
-			}
-		} else {
-			if len(*t.MusicServiceBaseDomain) > 1000000 {
-				return xerrors.Errorf("Value in field t.MusicServiceBaseDomain was too long")
-			}
-
-			if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(*t.MusicServiceBaseDomain))); err != nil {
-				return err
-			}
-			if _, err := cw.WriteString(string(*t.MusicServiceBaseDomain)); err != nil {
 				return err
 			}
 		}
@@ -2378,7 +2378,7 @@ func (t *FeedDefs_PlayView) UnmarshalCBOR(r io.Reader) (err error) {
 
 	n := extra
 
-	nameBuf := make([]byte, 22)
+	nameBuf := make([]byte, 21)
 	for i := uint64(0); i < n; i++ {
 		nameLen, ok, err := cbg.ReadFullStringIntoBuf(cr, nameBuf, 1000000)
 		if err != nil {
@@ -2500,8 +2500,8 @@ func (t *FeedDefs_PlayView) UnmarshalCBOR(r io.Reader) (err error) {
 					t.Duration = (*int64)(&extraI)
 				}
 			}
-			// t.OriginUrl (string) (string)
-		case "originUrl":
+			// t.OriginUri (string) (string)
+		case "originUri":
 
 			{
 				b, err := cr.ReadByte()
@@ -2518,7 +2518,7 @@ func (t *FeedDefs_PlayView) UnmarshalCBOR(r io.Reader) (err error) {
 						return err
 					}
 
-					t.OriginUrl = (*string)(&sval)
+					t.OriginUri = (*string)(&sval)
 				}
 			}
 			// t.TrackMbId (string) (string)
@@ -2637,6 +2637,27 @@ func (t *FeedDefs_PlayView) UnmarshalCBOR(r io.Reader) (err error) {
 					t.RecordingMbId = (*string)(&sval)
 				}
 			}
+			// t.MusicServiceUri (string) (string)
+		case "musicServiceUri":
+
+			{
+				b, err := cr.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := cr.UnreadByte(); err != nil {
+						return err
+					}
+
+					sval, err := cbg.ReadStringWithMax(cr, 1000000)
+					if err != nil {
+						return err
+					}
+
+					t.MusicServiceUri = (*string)(&sval)
+				}
+			}
 			// t.SubmissionClientAgent (string) (string)
 		case "submissionClientAgent":
 
@@ -2656,27 +2677,6 @@ func (t *FeedDefs_PlayView) UnmarshalCBOR(r io.Reader) (err error) {
 					}
 
 					t.SubmissionClientAgent = (*string)(&sval)
-				}
-			}
-			// t.MusicServiceBaseDomain (string) (string)
-		case "musicServiceBaseDomain":
-
-			{
-				b, err := cr.ReadByte()
-				if err != nil {
-					return err
-				}
-				if b != cbg.CborNull[0] {
-					if err := cr.UnreadByte(); err != nil {
-						return err
-					}
-
-					sval, err := cbg.ReadStringWithMax(cr, 1000000)
-					if err != nil {
-						return err
-					}
-
-					t.MusicServiceBaseDomain = (*string)(&sval)
 				}
 			}
 

--- a/api/teal/cbor_gen.go
+++ b/api/teal/cbor_gen.go
@@ -20,7 +20,7 @@ var _ = cid.Undef
 var _ = math.E
 var _ = sort.Sort
 
-func (t *AlphaFeedPlay) MarshalCBOR(w io.Writer) error {
+func (t *FeedPlay) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
@@ -137,14 +137,14 @@ func (t *AlphaFeedPlay) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("fm.teal.alpha.feed.play"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("fm.teal.feed.play"))); err != nil {
 		return err
 	}
-	if _, err := cw.WriteString(string("fm.teal.alpha.feed.play")); err != nil {
+	if _, err := cw.WriteString(string("fm.teal.feed.play")); err != nil {
 		return err
 	}
 
-	// t.Artists ([]*teal.AlphaFeedDefs_Artist) (slice)
+	// t.Artists ([]*teal.FeedDefs_Artist) (slice)
 	if t.Artists != nil {
 
 		if len("artists") > 1000000 {
@@ -622,8 +622,8 @@ func (t *AlphaFeedPlay) MarshalCBOR(w io.Writer) error {
 	return nil
 }
 
-func (t *AlphaFeedPlay) UnmarshalCBOR(r io.Reader) (err error) {
-	*t = AlphaFeedPlay{}
+func (t *FeedPlay) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = FeedPlay{}
 
 	cr := cbg.NewCborReader(r)
 
@@ -642,7 +642,7 @@ func (t *AlphaFeedPlay) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 
 	if extra > cbg.MaxLength {
-		return fmt.Errorf("AlphaFeedPlay: map struct too large (%d)", extra)
+		return fmt.Errorf("FeedPlay: map struct too large (%d)", extra)
 	}
 
 	n := extra
@@ -695,7 +695,7 @@ func (t *AlphaFeedPlay) UnmarshalCBOR(r io.Reader) (err error) {
 
 				t.LexiconTypeID = string(sval)
 			}
-			// t.Artists ([]*teal.AlphaFeedDefs_Artist) (slice)
+			// t.Artists ([]*teal.FeedDefs_Artist) (slice)
 		case "artists":
 
 			maj, extra, err = cr.ReadHeader()
@@ -712,7 +712,7 @@ func (t *AlphaFeedPlay) UnmarshalCBOR(r io.Reader) (err error) {
 			}
 
 			if extra > 0 {
-				t.Artists = make([]*AlphaFeedDefs_Artist, extra)
+				t.Artists = make([]*FeedDefs_Artist, extra)
 			}
 
 			for i := 0; i < int(extra); i++ {
@@ -734,7 +734,7 @@ func (t *AlphaFeedPlay) UnmarshalCBOR(r io.Reader) (err error) {
 							if err := cr.UnreadByte(); err != nil {
 								return err
 							}
-							t.Artists[i] = new(AlphaFeedDefs_Artist)
+							t.Artists[i] = new(FeedDefs_Artist)
 							if err := t.Artists[i].UnmarshalCBOR(cr); err != nil {
 								return xerrors.Errorf("unmarshaling t.Artists[i] pointer: %w", err)
 							}
@@ -1092,7 +1092,7 @@ func (t *AlphaFeedPlay) UnmarshalCBOR(r io.Reader) (err error) {
 
 	return nil
 }
-func (t *AlphaActorProfile) MarshalCBOR(w io.Writer) error {
+func (t *ActorProfile) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
@@ -1145,10 +1145,10 @@ func (t *AlphaActorProfile) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("fm.teal.alpha.actor.profile"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("fm.teal.actor.profile"))); err != nil {
 		return err
 	}
-	if _, err := cw.WriteString(string("fm.teal.alpha.actor.profile")); err != nil {
+	if _, err := cw.WriteString(string("fm.teal.actor.profile")); err != nil {
 		return err
 	}
 
@@ -1286,7 +1286,7 @@ func (t *AlphaActorProfile) MarshalCBOR(w io.Writer) error {
 		}
 	}
 
-	// t.FeaturedItem (teal.AlphaActorProfile_FeaturedItem) (struct)
+	// t.FeaturedItem (teal.ActorProfile_FeaturedItem) (struct)
 	if t.FeaturedItem != nil {
 
 		if len("featuredItem") > 1000000 {
@@ -1336,8 +1336,8 @@ func (t *AlphaActorProfile) MarshalCBOR(w io.Writer) error {
 	return nil
 }
 
-func (t *AlphaActorProfile) UnmarshalCBOR(r io.Reader) (err error) {
-	*t = AlphaActorProfile{}
+func (t *ActorProfile) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = ActorProfile{}
 
 	cr := cbg.NewCborReader(r)
 
@@ -1356,7 +1356,7 @@ func (t *AlphaActorProfile) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 
 	if extra > cbg.MaxLength {
-		return fmt.Errorf("AlphaActorProfile: map struct too large (%d)", extra)
+		return fmt.Errorf("ActorProfile: map struct too large (%d)", extra)
 	}
 
 	n := extra
@@ -1491,7 +1491,7 @@ func (t *AlphaActorProfile) UnmarshalCBOR(r io.Reader) (err error) {
 					t.DisplayName = (*string)(&sval)
 				}
 			}
-			// t.FeaturedItem (teal.AlphaActorProfile_FeaturedItem) (struct)
+			// t.FeaturedItem (teal.ActorProfile_FeaturedItem) (struct)
 		case "featuredItem":
 
 			{
@@ -1504,7 +1504,7 @@ func (t *AlphaActorProfile) UnmarshalCBOR(r io.Reader) (err error) {
 					if err := cr.UnreadByte(); err != nil {
 						return err
 					}
-					t.FeaturedItem = new(AlphaActorProfile_FeaturedItem)
+					t.FeaturedItem = new(ActorProfile_FeaturedItem)
 					if err := t.FeaturedItem.UnmarshalCBOR(cr); err != nil {
 						return xerrors.Errorf("unmarshaling t.FeaturedItem pointer: %w", err)
 					}
@@ -1571,7 +1571,7 @@ func (t *AlphaActorProfile) UnmarshalCBOR(r io.Reader) (err error) {
 
 	return nil
 }
-func (t *AlphaActorStatus) MarshalCBOR(w io.Writer) error {
+func (t *ActorStatus) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
@@ -1588,7 +1588,7 @@ func (t *AlphaActorStatus) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.Item (teal.AlphaFeedDefs_PlayView) (struct)
+	// t.Item (teal.FeedDefs_PlayView) (struct)
 	if len("item") > 1000000 {
 		return xerrors.Errorf("Value in field \"item\" was too long")
 	}
@@ -1639,10 +1639,10 @@ func (t *AlphaActorStatus) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("fm.teal.alpha.actor.status"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("fm.teal.actor.status"))); err != nil {
 		return err
 	}
-	if _, err := cw.WriteString(string("fm.teal.alpha.actor.status")); err != nil {
+	if _, err := cw.WriteString(string("fm.teal.actor.status")); err != nil {
 		return err
 	}
 
@@ -1680,8 +1680,8 @@ func (t *AlphaActorStatus) MarshalCBOR(w io.Writer) error {
 	return nil
 }
 
-func (t *AlphaActorStatus) UnmarshalCBOR(r io.Reader) (err error) {
-	*t = AlphaActorStatus{}
+func (t *ActorStatus) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = ActorStatus{}
 
 	cr := cbg.NewCborReader(r)
 
@@ -1700,7 +1700,7 @@ func (t *AlphaActorStatus) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 
 	if extra > cbg.MaxLength {
-		return fmt.Errorf("AlphaActorStatus: map struct too large (%d)", extra)
+		return fmt.Errorf("ActorStatus: map struct too large (%d)", extra)
 	}
 
 	n := extra
@@ -1721,7 +1721,7 @@ func (t *AlphaActorStatus) UnmarshalCBOR(r io.Reader) (err error) {
 		}
 
 		switch string(nameBuf[:nameLen]) {
-		// t.Item (teal.AlphaFeedDefs_PlayView) (struct)
+		// t.Item (teal.FeedDefs_PlayView) (struct)
 		case "item":
 
 			{
@@ -1734,7 +1734,7 @@ func (t *AlphaActorStatus) UnmarshalCBOR(r io.Reader) (err error) {
 					if err := cr.UnreadByte(); err != nil {
 						return err
 					}
-					t.Item = new(AlphaFeedDefs_PlayView)
+					t.Item = new(FeedDefs_PlayView)
 					if err := t.Item.UnmarshalCBOR(cr); err != nil {
 						return xerrors.Errorf("unmarshaling t.Item pointer: %w", err)
 					}
@@ -1795,7 +1795,7 @@ func (t *AlphaActorStatus) UnmarshalCBOR(r io.Reader) (err error) {
 
 	return nil
 }
-func (t *AlphaActorProfile_FeaturedItem) MarshalCBOR(w io.Writer) error {
+func (t *ActorProfile_FeaturedItem) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
@@ -1855,8 +1855,8 @@ func (t *AlphaActorProfile_FeaturedItem) MarshalCBOR(w io.Writer) error {
 	return nil
 }
 
-func (t *AlphaActorProfile_FeaturedItem) UnmarshalCBOR(r io.Reader) (err error) {
-	*t = AlphaActorProfile_FeaturedItem{}
+func (t *ActorProfile_FeaturedItem) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = ActorProfile_FeaturedItem{}
 
 	cr := cbg.NewCborReader(r)
 
@@ -1875,7 +1875,7 @@ func (t *AlphaActorProfile_FeaturedItem) UnmarshalCBOR(r io.Reader) (err error) 
 	}
 
 	if extra > cbg.MaxLength {
-		return fmt.Errorf("AlphaActorProfile_FeaturedItem: map struct too large (%d)", extra)
+		return fmt.Errorf("ActorProfile_FeaturedItem: map struct too large (%d)", extra)
 	}
 
 	n := extra
@@ -1929,7 +1929,7 @@ func (t *AlphaActorProfile_FeaturedItem) UnmarshalCBOR(r io.Reader) (err error) 
 
 	return nil
 }
-func (t *AlphaFeedDefs_PlayView) MarshalCBOR(w io.Writer) error {
+func (t *FeedDefs_PlayView) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
@@ -2014,7 +2014,7 @@ func (t *AlphaFeedDefs_PlayView) MarshalCBOR(w io.Writer) error {
 		}
 	}
 
-	// t.Artists ([]*teal.AlphaFeedDefs_Artist) (slice)
+	// t.Artists ([]*teal.FeedDefs_Artist) (slice)
 	if len("artists") > 1000000 {
 		return xerrors.Errorf("Value in field \"artists\" was too long")
 	}
@@ -2353,8 +2353,8 @@ func (t *AlphaFeedDefs_PlayView) MarshalCBOR(w io.Writer) error {
 	return nil
 }
 
-func (t *AlphaFeedDefs_PlayView) UnmarshalCBOR(r io.Reader) (err error) {
-	*t = AlphaFeedDefs_PlayView{}
+func (t *FeedDefs_PlayView) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = FeedDefs_PlayView{}
 
 	cr := cbg.NewCborReader(r)
 
@@ -2373,7 +2373,7 @@ func (t *AlphaFeedDefs_PlayView) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 
 	if extra > cbg.MaxLength {
-		return fmt.Errorf("AlphaFeedDefs_PlayView: map struct too large (%d)", extra)
+		return fmt.Errorf("FeedDefs_PlayView: map struct too large (%d)", extra)
 	}
 
 	n := extra
@@ -2415,7 +2415,7 @@ func (t *AlphaFeedDefs_PlayView) UnmarshalCBOR(r io.Reader) (err error) {
 					t.Isrc = (*string)(&sval)
 				}
 			}
-			// t.Artists ([]*teal.AlphaFeedDefs_Artist) (slice)
+			// t.Artists ([]*teal.FeedDefs_Artist) (slice)
 		case "artists":
 
 			maj, extra, err = cr.ReadHeader()
@@ -2432,7 +2432,7 @@ func (t *AlphaFeedDefs_PlayView) UnmarshalCBOR(r io.Reader) (err error) {
 			}
 
 			if extra > 0 {
-				t.Artists = make([]*AlphaFeedDefs_Artist, extra)
+				t.Artists = make([]*FeedDefs_Artist, extra)
 			}
 
 			for i := 0; i < int(extra); i++ {
@@ -2454,7 +2454,7 @@ func (t *AlphaFeedDefs_PlayView) UnmarshalCBOR(r io.Reader) (err error) {
 							if err := cr.UnreadByte(); err != nil {
 								return err
 							}
-							t.Artists[i] = new(AlphaFeedDefs_Artist)
+							t.Artists[i] = new(FeedDefs_Artist)
 							if err := t.Artists[i].UnmarshalCBOR(cr); err != nil {
 								return xerrors.Errorf("unmarshaling t.Artists[i] pointer: %w", err)
 							}
@@ -2690,7 +2690,7 @@ func (t *AlphaFeedDefs_PlayView) UnmarshalCBOR(r io.Reader) (err error) {
 
 	return nil
 }
-func (t *AlphaFeedDefs_Artist) MarshalCBOR(w io.Writer) error {
+func (t *FeedDefs_Artist) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
@@ -2764,8 +2764,8 @@ func (t *AlphaFeedDefs_Artist) MarshalCBOR(w io.Writer) error {
 	return nil
 }
 
-func (t *AlphaFeedDefs_Artist) UnmarshalCBOR(r io.Reader) (err error) {
-	*t = AlphaFeedDefs_Artist{}
+func (t *FeedDefs_Artist) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = FeedDefs_Artist{}
 
 	cr := cbg.NewCborReader(r)
 
@@ -2784,7 +2784,7 @@ func (t *AlphaFeedDefs_Artist) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 
 	if extra > cbg.MaxLength {
-		return fmt.Errorf("AlphaFeedDefs_Artist: map struct too large (%d)", extra)
+		return fmt.Errorf("FeedDefs_Artist: map struct too large (%d)", extra)
 	}
 
 	n := extra

--- a/api/teal/feeddefs.go
+++ b/api/teal/feeddefs.go
@@ -20,11 +20,11 @@ type FeedDefs_PlayView struct {
 	Duration *int64 `json:"duration,omitempty" cborgen:"duration,omitempty"`
 	// isrc: The ISRC code associated with the recording
 	Isrc *string `json:"isrc,omitempty" cborgen:"isrc,omitempty"`
-	// musicServiceBaseDomain: The base domain of the music service. e.g. music.apple.com, tidal.com, spotify.com. Defaults to 'local' if not provided.
-	MusicServiceBaseDomain *string `json:"musicServiceBaseDomain,omitempty" cborgen:"musicServiceBaseDomain,omitempty"`
-	// originUrl: The URL associated with this track
-	OriginUrl *string `json:"originUrl,omitempty" cborgen:"originUrl,omitempty"`
-	// playedTime: The unix timestamp of when the track was played
+	// musicServiceUri: The canonical URI identifying the listening surface or music service.
+	MusicServiceUri *string `json:"musicServiceUri,omitempty" cborgen:"musicServiceUri,omitempty"`
+	// originUri: The exact URI where the listening event originated.
+	OriginUri *string `json:"originUri,omitempty" cborgen:"originUri,omitempty"`
+	// playedTime: The datetime at which playback began.
 	PlayedTime *string `json:"playedTime,omitempty" cborgen:"playedTime,omitempty"`
 	// recordingMbId: The MusicBrainz recording ID URI of the track, formatted as mbid:<uuid>
 	RecordingMbId *string `json:"recordingMbId,omitempty" cborgen:"recordingMbId,omitempty"`

--- a/api/teal/feeddefs.go
+++ b/api/teal/feeddefs.go
@@ -2,20 +2,20 @@
 
 package teal
 
-// schema: fm.teal.alpha.feed.defs
+// schema: fm.teal.feed.defs
 
-// AlphaFeedDefs_Artist is a "artist" in the fm.teal.alpha.feed.defs schema.
-type AlphaFeedDefs_Artist struct {
+// FeedDefs_Artist is a "artist" in the fm.teal.feed.defs schema.
+type FeedDefs_Artist struct {
 	// artistMbId: The MusicBrainz artist ID URI, formatted as mbid:<uuid>
 	ArtistMbId *string `json:"artistMbId,omitempty" cborgen:"artistMbId,omitempty"`
 	// artistName: The name of the artist
 	ArtistName string `json:"artistName" cborgen:"artistName"`
 }
 
-// AlphaFeedDefs_PlayView is a "playView" in the fm.teal.alpha.feed.defs schema.
-type AlphaFeedDefs_PlayView struct {
+// FeedDefs_PlayView is a "playView" in the fm.teal.feed.defs schema.
+type FeedDefs_PlayView struct {
 	// artists: Array of artists in order of original appearance.
-	Artists []*AlphaFeedDefs_Artist `json:"artists" cborgen:"artists"`
+	Artists []*FeedDefs_Artist `json:"artists" cborgen:"artists"`
 	// duration: The length of the track in seconds
 	Duration *int64 `json:"duration,omitempty" cborgen:"duration,omitempty"`
 	// isrc: The ISRC code associated with the recording

--- a/api/teal/feedgetActorFeed.go
+++ b/api/teal/feedgetActorFeed.go
@@ -2,7 +2,7 @@
 
 package teal
 
-// schema: fm.teal.alpha.feed.getActorFeed
+// schema: fm.teal.feed.getActorFeed
 
 import (
 	"context"
@@ -10,18 +10,18 @@ import (
 	"github.com/bluesky-social/indigo/lex/util"
 )
 
-// AlphaFeedGetActorFeed_Output is the output of a fm.teal.alpha.feed.getActorFeed call.
-type AlphaFeedGetActorFeed_Output struct {
-	Plays []*AlphaFeedDefs_PlayView `json:"plays" cborgen:"plays"`
+// FeedGetActorFeed_Output is the output of a fm.teal.feed.getActorFeed call.
+type FeedGetActorFeed_Output struct {
+	Plays []*FeedDefs_PlayView `json:"plays" cborgen:"plays"`
 }
 
-// AlphaFeedGetActorFeed calls the XRPC method "fm.teal.alpha.feed.getActorFeed".
+// FeedGetActorFeed calls the XRPC method "fm.teal.feed.getActorFeed".
 //
 // authorDID: The author's DID for the play
 // cursor: The cursor to start the query from
 // limit: The upper limit of tracks to get per request. Default is 20, max is 50.
-func AlphaFeedGetActorFeed(ctx context.Context, c util.LexClient, authorDID string, cursor string, limit int64) (*AlphaFeedGetActorFeed_Output, error) {
-	var out AlphaFeedGetActorFeed_Output
+func FeedGetActorFeed(ctx context.Context, c util.LexClient, authorDID string, cursor string, limit int64) (*FeedGetActorFeed_Output, error) {
+	var out FeedGetActorFeed_Output
 
 	params := map[string]interface{}{}
 	params["authorDID"] = authorDID
@@ -31,7 +31,7 @@ func AlphaFeedGetActorFeed(ctx context.Context, c util.LexClient, authorDID stri
 	if limit != 0 {
 		params["limit"] = limit
 	}
-	if err := c.LexDo(ctx, util.Query, "", "fm.teal.alpha.feed.getActorFeed", params, nil, &out); err != nil {
+	if err := c.LexDo(ctx, util.Query, "", "fm.teal.feed.getActorFeed", params, nil, &out); err != nil {
 		return nil, err
 	}
 

--- a/api/teal/feedgetPlay.go
+++ b/api/teal/feedgetPlay.go
@@ -2,7 +2,7 @@
 
 package teal
 
-// schema: fm.teal.alpha.feed.getPlay
+// schema: fm.teal.feed.getPlay
 
 import (
 	"context"
@@ -10,22 +10,22 @@ import (
 	"github.com/bluesky-social/indigo/lex/util"
 )
 
-// AlphaFeedGetPlay_Output is the output of a fm.teal.alpha.feed.getPlay call.
-type AlphaFeedGetPlay_Output struct {
-	Play *AlphaFeedDefs_PlayView `json:"play" cborgen:"play"`
+// FeedGetPlay_Output is the output of a fm.teal.feed.getPlay call.
+type FeedGetPlay_Output struct {
+	Play *FeedDefs_PlayView `json:"play" cborgen:"play"`
 }
 
-// AlphaFeedGetPlay calls the XRPC method "fm.teal.alpha.feed.getPlay".
+// FeedGetPlay calls the XRPC method "fm.teal.feed.getPlay".
 //
 // authorDID: The author's DID for the play
 // rkey: The record key of the play
-func AlphaFeedGetPlay(ctx context.Context, c util.LexClient, authorDID string, rkey string) (*AlphaFeedGetPlay_Output, error) {
-	var out AlphaFeedGetPlay_Output
+func FeedGetPlay(ctx context.Context, c util.LexClient, authorDID string, rkey string) (*FeedGetPlay_Output, error) {
+	var out FeedGetPlay_Output
 
 	params := map[string]interface{}{}
 	params["authorDID"] = authorDID
 	params["rkey"] = rkey
-	if err := c.LexDo(ctx, util.Query, "", "fm.teal.alpha.feed.getPlay", params, nil, &out); err != nil {
+	if err := c.LexDo(ctx, util.Query, "", "fm.teal.feed.getPlay", params, nil, &out); err != nil {
 		return nil, err
 	}
 

--- a/api/teal/feedplay.go
+++ b/api/teal/feedplay.go
@@ -19,11 +19,11 @@ type FeedPlay struct {
 	Duration *int64 `json:"duration,omitempty" cborgen:"duration,omitempty"`
 	// isrc: The ISRC code associated with the recording
 	Isrc *string `json:"isrc,omitempty" cborgen:"isrc,omitempty"`
-	// musicServiceBaseDomain: The base domain of the music service. e.g. music.apple.com, tidal.com, spotify.com. Defaults to 'local' if unavailable or not provided.
-	MusicServiceBaseDomain *string `json:"musicServiceBaseDomain,omitempty" cborgen:"musicServiceBaseDomain,omitempty"`
-	// originUrl: The URL associated with this track
-	OriginUrl *string `json:"originUrl,omitempty" cborgen:"originUrl,omitempty"`
-	// playedTime: The unix timestamp of when the track was played
+	// musicServiceUri: The canonical URI identifying the listening surface or music service.
+	MusicServiceUri *string `json:"musicServiceUri,omitempty" cborgen:"musicServiceUri,omitempty"`
+	// originUri: The exact URI where the listening event originated.
+	OriginUri *string `json:"originUri,omitempty" cborgen:"originUri,omitempty"`
+	// playedTime: The datetime at which playback began.
 	PlayedTime *string `json:"playedTime,omitempty" cborgen:"playedTime,omitempty"`
 	// recordingMbId: The MusicBrainz recording ID URI of the track, formatted as mbid:<uuid>
 	RecordingMbId *string `json:"recordingMbId,omitempty" cborgen:"recordingMbId,omitempty"`

--- a/api/teal/feedplay.go
+++ b/api/teal/feedplay.go
@@ -4,17 +4,17 @@ package teal
 
 import "github.com/bluesky-social/indigo/lex/util"
 
-// schema: fm.teal.alpha.feed.play
+// schema: fm.teal.feed.play
 
-// RECORDTYPE: AlphaFeedPlay
-type AlphaFeedPlay struct {
-	LexiconTypeID string `json:"$type,const=fm.teal.alpha.feed.play" cborgen:"$type,const=fm.teal.alpha.feed.play"`
+// RECORDTYPE: FeedPlay
+type FeedPlay struct {
+	LexiconTypeID string `json:"$type,const=fm.teal.feed.play" cborgen:"$type,const=fm.teal.feed.play"`
 	// artistMbIds: DEPRECATED: USE 'artists' INSTEAD. Array of Musicbrainz artist IDs.
 	ArtistMbIds []string `json:"artistMbIds,omitempty" cborgen:"artistMbIds,omitempty"`
 	// artistNames: DEPRECATED: USE 'artists' INSTEAD. Array of artist names in order of original appearance.
 	ArtistNames []string `json:"artistNames,omitempty" cborgen:"artistNames,omitempty"`
 	// artists: Array of artists in order of original appearance.
-	Artists []*AlphaFeedDefs_Artist `json:"artists,omitempty" cborgen:"artists,omitempty"`
+	Artists []*FeedDefs_Artist `json:"artists,omitempty" cborgen:"artists,omitempty"`
 	// duration: The length of the track in seconds
 	Duration *int64 `json:"duration,omitempty" cborgen:"duration,omitempty"`
 	// isrc: The ISRC code associated with the recording
@@ -44,5 +44,5 @@ type AlphaFeedPlay struct {
 }
 
 func init() {
-	util.RegisterType("fm.teal.alpha.feed.play", &AlphaFeedPlay{})
+	util.RegisterType("fm.teal.feed.play", &FeedPlay{})
 }

--- a/cmd/lexgen/main.go
+++ b/cmd/lexgen/main.go
@@ -39,12 +39,12 @@ var modules = []moduleConfig{
 		pkgName:    "teal",
 		cborOut:    "api/teal/cbor_gen.go",
 		cborTypes: []string{
-			"teal.AlphaFeedPlay",
-			"teal.AlphaActorProfile",
-			"teal.AlphaActorStatus",
-			"teal.AlphaActorProfile_FeaturedItem",
-			"teal.AlphaFeedDefs_PlayView",
-			"teal.AlphaFeedDefs_Artist",
+			"teal.FeedPlay",
+			"teal.ActorProfile",
+			"teal.ActorStatus",
+			"teal.ActorProfile_FeaturedItem",
+			"teal.FeedDefs_PlayView",
+			"teal.FeedDefs_Artist",
 		},
 	},
 }

--- a/lexicons/teal/actor/defs.json
+++ b/lexicons/teal/actor/defs.json
@@ -1,6 +1,6 @@
 {
   "lexicon": 1,
-  "id": "fm.teal.alpha.actor.defs",
+  "id": "fm.teal.actor.defs",
   "defs": {
     "profileView": {
       "type": "object",
@@ -24,7 +24,7 @@
         "featuredItem": {
           "type": "ref",
           "description": "The user's most recent item featured on their profile.",
-          "ref": "fm.teal.alpha.actor.profile#featuredItem"
+          "ref": "fm.teal.actor.profile#featuredItem"
         },
         "avatar": {
           "type": "string",
@@ -76,7 +76,7 @@
         },
         "item": {
           "type": "ref",
-          "ref": "fm.teal.alpha.feed.defs#playView"
+          "ref": "fm.teal.feed.defs#playView"
         }
       }
     }

--- a/lexicons/teal/actor/getProfile.json
+++ b/lexicons/teal/actor/getProfile.json
@@ -1,6 +1,6 @@
 {
   "lexicon": 1,
-  "id": "fm.teal.alpha.actor.getProfile",
+  "id": "fm.teal.actor.getProfile",
   "description": "This lexicon is in a not officially released state. It is subject to change. | Retrieves a play given an author DID and record key.",
   "defs": {
     "main": {
@@ -24,7 +24,7 @@
           "properties": {
             "actor": {
               "type": "ref",
-              "ref": "fm.teal.alpha.actor.defs#profileView"
+              "ref": "fm.teal.actor.defs#profileView"
             }
           }
         }

--- a/lexicons/teal/actor/getProfiles.json
+++ b/lexicons/teal/actor/getProfiles.json
@@ -1,6 +1,6 @@
 {
   "lexicon": 1,
-  "id": "fm.teal.alpha.actor.getProfiles",
+  "id": "fm.teal.actor.getProfiles",
   "description": "This lexicon is in a not officially released state. It is subject to change. | Retrieves the associated profile.",
   "defs": {
     "main": {
@@ -29,7 +29,7 @@
               "type": "array",
               "items": {
                 "type": "ref",
-                "ref": "fm.teal.alpha.actor.defs#miniProfileView"
+                "ref": "fm.teal.actor.defs#miniProfileView"
               }
             }
           }

--- a/lexicons/teal/actor/profile.json
+++ b/lexicons/teal/actor/profile.json
@@ -1,6 +1,6 @@
 {
   "lexicon": 1,
-  "id": "fm.teal.alpha.actor.profile",
+  "id": "fm.teal.actor.profile",
   "defs": {
     "main": {
       "type": "record",

--- a/lexicons/teal/actor/searchActors.json
+++ b/lexicons/teal/actor/searchActors.json
@@ -1,6 +1,6 @@
 {
   "lexicon": 1,
-  "id": "fm.teal.alpha.actor.searchActors",
+  "id": "fm.teal.actor.searchActors",
   "description": "This lexicon is in a not officially released state. It is subject to change. | Searches for actors based on profile contents.",
   "defs": {
     "main": {
@@ -37,7 +37,7 @@
               "type": "array",
               "items": {
                 "type": "ref",
-                "ref": "fm.teal.alpha.actor.defs#miniProfileView"
+                "ref": "fm.teal.actor.defs#miniProfileView"
               }
             },
             "cursor": {

--- a/lexicons/teal/actor/status.json
+++ b/lexicons/teal/actor/status.json
@@ -1,6 +1,6 @@
 {
   "lexicon": 1,
-  "id": "fm.teal.alpha.actor.status",
+  "id": "fm.teal.actor.status",
   "defs": {
     "main": {
       "type": "record",
@@ -22,7 +22,7 @@
           },
           "item": {
             "type": "ref",
-            "ref": "fm.teal.alpha.feed.defs#playView"
+            "ref": "fm.teal.feed.defs#playView"
           }
         }
       }

--- a/lexicons/teal/feed/defs.json
+++ b/lexicons/teal/feed/defs.json
@@ -51,13 +51,15 @@
           "type": "string",
           "description": "The ISRC code associated with the recording"
         },
-        "originUrl": {
+        "originUri": {
           "type": "string",
-          "description": "The URL associated with this track"
+          "format": "uri",
+          "description": "The exact URI where the listening event originated."
         },
-        "musicServiceBaseDomain": {
+        "musicServiceUri": {
           "type": "string",
-          "description": "The base domain of the music service. e.g. music.apple.com, tidal.com, spotify.com. Defaults to 'local' if not provided."
+          "format": "uri",
+          "description": "The canonical URI identifying the listening surface or music service."
         },
         "submissionClientAgent": {
           "type": "string",
@@ -68,7 +70,7 @@
         "playedTime": {
           "type": "string",
           "format": "datetime",
-          "description": "The unix timestamp of when the track was played"
+          "description": "The datetime at which playback began."
         }
       }
     },

--- a/lexicons/teal/feed/defs.json
+++ b/lexicons/teal/feed/defs.json
@@ -1,6 +1,6 @@
 {
   "lexicon": 1,
-  "id": "fm.teal.alpha.feed.defs",
+  "id": "fm.teal.feed.defs",
   "description": "This lexicon is in a not officially released state. It is subject to change. | Misc. items related to feeds.",
   "defs": {
     "playView": {

--- a/lexicons/teal/feed/getActorFeed.json
+++ b/lexicons/teal/feed/getActorFeed.json
@@ -1,6 +1,6 @@
 {
   "lexicon": 1,
-  "id": "fm.teal.alpha.feed.getActorFeed",
+  "id": "fm.teal.feed.getActorFeed",
   "description": "This lexicon is in a not officially released state. It is subject to change. | Retrieves multiple plays from the index or via an author's DID.",
   "defs": {
     "main": {
@@ -34,7 +34,7 @@
               "type": "array",
               "items": {
                 "type": "ref",
-                "ref": "fm.teal.alpha.feed.defs#playView"
+                "ref": "fm.teal.feed.defs#playView"
               }
             }
           }

--- a/lexicons/teal/feed/getPlay.json
+++ b/lexicons/teal/feed/getPlay.json
@@ -1,6 +1,6 @@
 {
   "lexicon": 1,
-  "id": "fm.teal.alpha.feed.getPlay",
+  "id": "fm.teal.feed.getPlay",
   "description": "This lexicon is in a not officially released state. It is subject to change. | Retrieves a play given an author DID and record key.",
   "defs": {
     "main": {
@@ -28,7 +28,7 @@
           "properties": {
             "play": {
               "type": "ref",
-              "ref": "fm.teal.alpha.feed.defs#playView"
+              "ref": "fm.teal.feed.defs#playView"
             }
           }
         }

--- a/lexicons/teal/feed/play.json
+++ b/lexicons/teal/feed/play.json
@@ -1,6 +1,6 @@
 {
   "lexicon": 1,
-  "id": "fm.teal.alpha.feed.play",
+  "id": "fm.teal.feed.play",
   "description": "This lexicon is in a not officially released state. It is subject to change. | A declaration of a teal.fm play. Plays are submitted as a result of a user listening to a track. Plays should be marked as tracked when a user has listened to the entire track if it's under 2 minutes long, or half of the track's duration up to 4 minutes, whichever is longest.",
   "defs": {
     "main": {
@@ -52,7 +52,7 @@
             "type": "array",
             "items": {
               "type": "ref",
-              "ref": "fm.teal.alpha.feed.defs#artist"
+              "ref": "fm.teal.feed.defs#artist"
             },
             "description": "Array of artists in order of original appearance."
           },

--- a/lexicons/teal/feed/play.json
+++ b/lexicons/teal/feed/play.json
@@ -71,13 +71,15 @@
             "type": "string",
             "description": "The ISRC code associated with the recording"
           },
-          "originUrl": {
+          "originUri": {
             "type": "string",
-            "description": "The URL associated with this track"
+            "format": "uri",
+            "description": "The exact URI where the listening event originated."
           },
-          "musicServiceBaseDomain": {
+          "musicServiceUri": {
             "type": "string",
-            "description": "The base domain of the music service. e.g. music.apple.com, tidal.com, spotify.com. Defaults to 'local' if unavailable or not provided."
+            "format": "uri",
+            "description": "The canonical URI identifying the listening surface or music service."
           },
           "submissionClientAgent": {
             "type": "string",
@@ -88,7 +90,7 @@
           "playedTime": {
             "type": "string",
             "format": "datetime",
-            "description": "The unix timestamp of when the track was played"
+            "description": "The datetime at which playback began."
           },
           "trackDiscriminant": {
             "type": "string",

--- a/models/constants.go
+++ b/models/constants.go
@@ -1,3 +1,3 @@
 package models
 
-const SubmissionAgent = "piper/v0.0.7"
+const SubmissionAgent = "piper/v0.0.8"

--- a/models/lexicon_format.go
+++ b/models/lexicon_format.go
@@ -33,7 +33,7 @@ func FormatMBIDURI(id *string) *string {
 	return &formatted
 }
 
-func FormatMusicServiceBaseDomain(service string) *string {
+func FormatMusicServiceURI(service string) *string {
 	trimmed := strings.TrimSpace(service)
 	if trimmed == "" {
 		return nil
@@ -41,14 +41,13 @@ func FormatMusicServiceBaseDomain(service string) *string {
 
 	normalized := strings.ToLower(trimmed)
 	if alias, ok := serviceDomainAliases[normalized]; ok {
-		return &alias
+		normalized = alias
 	}
 
 	if strings.Contains(normalized, "://") {
 		parsed, err := url.Parse(normalized)
 		if err == nil && parsed.Hostname() != "" {
-			host := parsed.Hostname()
-			return &host
+			normalized = parsed.Hostname()
 		}
 	}
 
@@ -56,5 +55,6 @@ func FormatMusicServiceBaseDomain(service string) *string {
 		normalized = strings.SplitN(normalized, "/", 2)[0]
 	}
 
-	return &normalized
+	uri := "https://" + normalized
+	return &uri
 }

--- a/models/lexicon_format_test.go
+++ b/models/lexicon_format_test.go
@@ -23,23 +23,23 @@ func TestFormatMBIDURI(t *testing.T) {
 	}
 }
 
-func TestFormatMusicServiceBaseDomain(t *testing.T) {
+func TestFormatMusicServiceURI(t *testing.T) {
 	tests := []struct {
 		name string
 		in   string
 		want *string
 	}{
 		{name: "empty"},
-		{name: "alias", in: "spotify", want: strPtr("spotify.com")},
-		{name: "lastfm alias", in: "lastfm", want: strPtr("last.fm")},
-		{name: "url", in: "https://open.spotify.com/track/test", want: strPtr("open.spotify.com")},
-		{name: "domain with path", in: "music.apple.com/us/album/test", want: strPtr("music.apple.com")},
-		{name: "domain", in: "ListenBrainz.org", want: strPtr("listenbrainz.org")},
+		{name: "alias", in: "spotify", want: strPtr("https://spotify.com")},
+		{name: "lastfm alias", in: "lastfm", want: strPtr("https://last.fm")},
+		{name: "url", in: "https://open.spotify.com/track/test", want: strPtr("https://open.spotify.com")},
+		{name: "domain with path", in: "music.apple.com/us/album/test", want: strPtr("https://music.apple.com")},
+		{name: "domain", in: "ListenBrainz.org", want: strPtr("https://listenbrainz.org")},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := FormatMusicServiceBaseDomain(tt.in)
+			got := FormatMusicServiceURI(tt.in)
 			assertStringPtr(t, got, tt.want)
 		})
 	}

--- a/oauth/atproto/atproto.go
+++ b/oauth/atproto/atproto.go
@@ -32,7 +32,7 @@ type AuthService struct {
 func NewATprotoAuthService(database *db.DB, sessionManager *session.Manager, clientSecretKey string, clientId string, callbackUrl string, clientSecretId string, allowedDids []string) (*AuthService, error) {
 	fmt.Println(clientId, callbackUrl)
 
-	scopes := []string{"atproto", "repo:fm.teal.alpha.feed.play", "repo:fm.teal.alpha.actor.status"}
+	scopes := []string{"atproto", "repo:fm.teal.feed.play", "repo:fm.teal.actor.status"}
 
 	var config oauth.ClientConfig
 	config = oauth.NewPublicConfig(clientId, callbackUrl, scopes)

--- a/service/atproto/submission.go
+++ b/service/atproto/submission.go
@@ -34,7 +34,7 @@ func SubmitPlayToPDS(ctx context.Context, did string, mostRecentAtProtoSessionID
 
 	// Create the record
 	input := comatproto.RepoCreateRecord_Input{
-		Collection: "fm.teal.alpha.feed.play",
+		Collection: "fm.teal.feed.play",
 		Repo:       client.AccountDID.String(),
 		Record:     &lexutil.LexiconTypeDecoder{Val: playRecord},
 	}
@@ -47,16 +47,16 @@ func SubmitPlayToPDS(ctx context.Context, did string, mostRecentAtProtoSessionID
 	return nil
 }
 
-// TrackToPlayRecord converts a models.Track to teal.AlphaFeedPlay
-func TrackToPlayRecord(track *models.Track) (*teal.AlphaFeedPlay, error) {
+// TrackToPlayRecord converts a models.Track to teal.FeedPlay
+func TrackToPlayRecord(track *models.Track) (*teal.FeedPlay, error) {
 	if track.Name == "" {
 		return nil, fmt.Errorf("track name cannot be empty")
 	}
 
 	// Convert artists
-	artists := make([]*teal.AlphaFeedDefs_Artist, 0, len(track.Artist))
+	artists := make([]*teal.FeedDefs_Artist, 0, len(track.Artist))
 	for _, a := range track.Artist {
-		artist := &teal.AlphaFeedDefs_Artist{
+		artist := &teal.FeedDefs_Artist{
 			ArtistName: a.Name,
 			ArtistMbId: models.FormatMBIDURI(a.MBID),
 		}
@@ -99,8 +99,8 @@ func TrackToPlayRecord(track *models.Track) (*teal.AlphaFeedPlay, error) {
 		submissionAgent = models.SubmissionAgent
 	}
 
-	playRecord := &teal.AlphaFeedPlay{
-		LexiconTypeID:          "fm.teal.alpha.feed.play",
+	playRecord := &teal.FeedPlay{
+		LexiconTypeID:          "fm.teal.feed.play",
 		TrackName:              track.Name,
 		Artists:                artists,
 		Duration:               durationPtr,

--- a/service/atproto/submission.go
+++ b/service/atproto/submission.go
@@ -81,12 +81,12 @@ func TrackToPlayRecord(track *models.Track) (*teal.FeedPlay, error) {
 		isrcPtr = &track.ISRC
 	}
 
-	var originUrlPtr *string
+	var originURI *string
 	if track.URL != "" {
-		originUrlPtr = &track.URL
+		originURI = &track.URL
 	}
 
-	servicePtr := models.FormatMusicServiceBaseDomain(track.ServiceBaseUrl)
+	serviceURI := models.FormatMusicServiceURI(track.ServiceBaseUrl)
 
 	var releaseNamePtr *string
 	if track.Album != "" {
@@ -100,18 +100,18 @@ func TrackToPlayRecord(track *models.Track) (*teal.FeedPlay, error) {
 	}
 
 	playRecord := &teal.FeedPlay{
-		LexiconTypeID:          "fm.teal.feed.play",
-		TrackName:              track.Name,
-		Artists:                artists,
-		Duration:               durationPtr,
-		PlayedTime:             playedTimeStr,
-		RecordingMbId:          models.FormatMBIDURI(track.RecordingMBID),
-		ReleaseMbId:            models.FormatMBIDURI(track.ReleaseMBID),
-		ReleaseName:            releaseNamePtr,
-		Isrc:                   isrcPtr,
-		OriginUrl:              originUrlPtr,
-		MusicServiceBaseDomain: servicePtr,
-		SubmissionClientAgent:  &submissionAgent,
+		LexiconTypeID:         "fm.teal.feed.play",
+		TrackName:             track.Name,
+		Artists:               artists,
+		Duration:              durationPtr,
+		PlayedTime:            playedTimeStr,
+		RecordingMbId:         models.FormatMBIDURI(track.RecordingMBID),
+		ReleaseMbId:           models.FormatMBIDURI(track.ReleaseMBID),
+		ReleaseName:           releaseNamePtr,
+		Isrc:                  isrcPtr,
+		OriginUri:             originURI,
+		MusicServiceUri:       serviceURI,
+		SubmissionClientAgent: &submissionAgent,
 	}
 
 	return playRecord, nil

--- a/service/playingnow/playingnow.go
+++ b/service/playingnow/playingnow.go
@@ -86,8 +86,8 @@ func (p *Service) PublishPlayingNow(ctx context.Context, userID int64, track *mo
 	now := time.Now()
 	expiry := now.Add(10 * time.Minute) // Default 10 minutes as mentioned in schema
 
-	status := &teal.AlphaActorStatus{
-		LexiconTypeID: "fm.teal.alpha.actor.status",
+	status := &teal.ActorStatus{
+		LexiconTypeID: "fm.teal.actor.status",
 		Time:          now.Format(time.RFC3339),
 		Expiry:        func() *string { s := expiry.Format(time.RFC3339); return &s }(),
 		Item:          playView,
@@ -108,7 +108,7 @@ func (p *Service) PublishPlayingNow(ctx context.Context, userID int64, track *mo
 
 	// Create the record input
 	input := comatproto.RepoPutRecord_Input{
-		Collection: "fm.teal.alpha.actor.status",
+		Collection: "fm.teal.actor.status",
 		Repo:       atProtoClient.AccountDID.String(),
 		Rkey:       "self", // Use "self" as the record key for current status
 		Record:     &lexutil.LexiconTypeDecoder{Val: status},
@@ -169,13 +169,13 @@ func (p *Service) ClearPlayingNow(ctx context.Context, userID int64) error {
 	expiredTime := now.Add(-1 * time.Minute) // Set expiry to 1 minute ago
 
 	// Create empty play view
-	emptyPlayView := &teal.AlphaFeedDefs_PlayView{
+	emptyPlayView := &teal.FeedDefs_PlayView{
 		TrackName: "", // Empty track indicates no current playing
-		Artists:   []*teal.AlphaFeedDefs_Artist{},
+		Artists:   []*teal.FeedDefs_Artist{},
 	}
 
-	status := &teal.AlphaActorStatus{
-		LexiconTypeID: "fm.teal.alpha.actor.status",
+	status := &teal.ActorStatus{
+		LexiconTypeID: "fm.teal.actor.status",
 		Time:          now.Format(time.RFC3339),
 		Expiry:        func() *string { s := expiredTime.Format(time.RFC3339); return &s }(),
 		Item:          emptyPlayView,
@@ -195,7 +195,7 @@ func (p *Service) ClearPlayingNow(ctx context.Context, userID int64) error {
 
 	// Update the record
 	input := comatproto.RepoPutRecord_Input{
-		Collection: "fm.teal.alpha.actor.status",
+		Collection: "fm.teal.actor.status",
 		Repo:       atProtoClient.AccountDID.String(),
 		Rkey:       "self",
 		Record:     &lexutil.LexiconTypeDecoder{Val: status},
@@ -217,16 +217,16 @@ func (p *Service) ClearPlayingNow(ctx context.Context, userID int64) error {
 	return nil
 }
 
-// trackToPlayView converts a models.Track to teal.AlphaFeedDefs_PlayView
-func (p *Service) trackToPlayView(track *models.Track) (*teal.AlphaFeedDefs_PlayView, error) {
+// trackToPlayView converts a models.Track to teal.FeedDefs_PlayView
+func (p *Service) trackToPlayView(track *models.Track) (*teal.FeedDefs_PlayView, error) {
 	if track.Name == "" {
 		return nil, fmt.Errorf("track name cannot be empty")
 	}
 
 	// Convert artists
-	artists := make([]*teal.AlphaFeedDefs_Artist, 0, len(track.Artist))
+	artists := make([]*teal.FeedDefs_Artist, 0, len(track.Artist))
 	for _, a := range track.Artist {
-		artist := &teal.AlphaFeedDefs_Artist{
+		artist := &teal.FeedDefs_Artist{
 			ArtistName: a.Name,
 			ArtistMbId: models.FormatMBIDURI(a.MBID),
 		}
@@ -269,7 +269,7 @@ func (p *Service) trackToPlayView(track *models.Track) (*teal.AlphaFeedDefs_Play
 		submissionAgent = models.SubmissionAgent
 	}
 
-	playView := &teal.AlphaFeedDefs_PlayView{
+	playView := &teal.FeedDefs_PlayView{
 		TrackName:              track.Name,
 		Artists:                artists,
 		Duration:               durationPtr,
@@ -289,7 +289,7 @@ func (p *Service) trackToPlayView(track *models.Track) (*teal.AlphaFeedDefs_Play
 // getStatusSwapRecord retrieves the current swap record (CID) for the actor status record.
 // Returns (nil, nil) if the record does not exist yet.
 func (p *Service) getStatusSwapRecord(ctx context.Context, atApiClient *client.APIClient) (*comatproto.RepoGetRecord_Output, error) {
-	result, err := comatproto.RepoGetRecord(ctx, atApiClient, "", "fm.teal.alpha.actor.status", atApiClient.AccountDID.String(), "self")
+	result, err := comatproto.RepoGetRecord(ctx, atApiClient, "", "fm.teal.actor.status", atApiClient.AccountDID.String(), "self")
 
 	if err != nil {
 		var xErr *client.APIError

--- a/service/playingnow/playingnow.go
+++ b/service/playingnow/playingnow.go
@@ -251,12 +251,12 @@ func (p *Service) trackToPlayView(track *models.Track) (*teal.FeedDefs_PlayView,
 		isrcPtr = &track.ISRC
 	}
 
-	var originUrlPtr *string
+	var originURI *string
 	if track.URL != "" {
-		originUrlPtr = &track.URL
+		originURI = &track.URL
 	}
 
-	servicePtr := models.FormatMusicServiceBaseDomain(track.ServiceBaseUrl)
+	serviceURI := models.FormatMusicServiceURI(track.ServiceBaseUrl)
 
 	var releaseNamePtr *string
 	if track.Album != "" {
@@ -270,17 +270,17 @@ func (p *Service) trackToPlayView(track *models.Track) (*teal.FeedDefs_PlayView,
 	}
 
 	playView := &teal.FeedDefs_PlayView{
-		TrackName:              track.Name,
-		Artists:                artists,
-		Duration:               durationPtr,
-		PlayedTime:             playedTimeStr,
-		RecordingMbId:          models.FormatMBIDURI(track.RecordingMBID),
-		ReleaseMbId:            models.FormatMBIDURI(track.ReleaseMBID),
-		ReleaseName:            releaseNamePtr,
-		Isrc:                   isrcPtr,
-		OriginUrl:              originUrlPtr,
-		MusicServiceBaseDomain: servicePtr,
-		SubmissionClientAgent:  &submissionAgent,
+		TrackName:             track.Name,
+		Artists:               artists,
+		Duration:              durationPtr,
+		PlayedTime:            playedTimeStr,
+		RecordingMbId:         models.FormatMBIDURI(track.RecordingMBID),
+		ReleaseMbId:           models.FormatMBIDURI(track.ReleaseMBID),
+		ReleaseName:           releaseNamePtr,
+		Isrc:                  isrcPtr,
+		OriginUri:             originURI,
+		MusicServiceUri:       serviceURI,
+		SubmissionClientAgent: &submissionAgent,
 	}
 
 	return playView, nil

--- a/service/playingnow/playingnow_test.go
+++ b/service/playingnow/playingnow_test.go
@@ -87,11 +87,11 @@ func TestTrackToPlayView(t *testing.T) {
 		t.Errorf("ISRC not set correctly")
 	}
 
-	if playView.OriginUrl == nil || *playView.OriginUrl != "https://open.spotify.com/track/test" {
+	if playView.OriginUri == nil || *playView.OriginUri != "https://open.spotify.com/track/test" {
 		t.Errorf("Origin URL not set correctly")
 	}
 
-	if playView.MusicServiceBaseDomain == nil || *playView.MusicServiceBaseDomain != "spotify.com" {
+	if playView.MusicServiceUri == nil || *playView.MusicServiceUri != "https://spotify.com" {
 		t.Errorf("Music service not set correctly")
 	}
 }

--- a/service/spotify/spotify.go
+++ b/service/spotify/spotify.go
@@ -20,7 +20,7 @@ import (
 	// Added for atproto.RepoCreateRecord_Input
 	// Added for lexutil.LexiconTypeDecoder
 	// Added for xrpc.Client
-	"github.com/spf13/viper" // Added for teal.AlphaFeedPlay
+	"github.com/spf13/viper" // Added for teal.FeedPlay
 	"github.com/teal-fm/piper/db"
 	"github.com/teal-fm/piper/models"
 	atprotoauth "github.com/teal-fm/piper/oauth/atproto"


### PR DESCRIPTION
Coauthored by GPT 5.6 Luna

## Summary

- Updated the vendored production play lexicons and regenerated the Go API/CBOR encoders.
- Updated Piper producer mappings to emit the canonical `originUri` and `musicServiceUri` fields as absolute HTTPS URIs.
- Kept OAuth scopes and all record writes on the production `fm.teal.*` namespace.

## Behavior and compatibility

Piper is a scrobbler/producer and does not consume existing listens, so it does not need dual alpha/production read support. New submissions use `fm.teal.feed.play`; legacy alpha records are not rewritten.

## Validation

- `make lexicon`
- `go test ./...`
- `git diff --check`
- Byte-for-byte comparison of `lexicons/teal/feed/play.json` and `lexicons/teal/feed/defs.json` against Teal main
- Confirmed no stale alpha namespace or old play-field references remain

Canonical source: `teal-fm/teal` main merge commit `82ea66cadbde3f1aee9c72b05f372c6543a4b3f6`, merged PR #110.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Finalized Teal actor and feed APIs under their standard namespace.
  * Added URI-based fields for content origins and music services.
  * Music service values are now normalized to HTTPS URIs.
* **Bug Fixes**
  * Updated playback and status publishing to use finalized schemas.
  * Clarified playback times as playback-start timestamps.
* **Refactor**
  * Renamed API types and methods to remove legacy alpha naming.
  * Updated OAuth scopes and record submission for the finalized APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->