### PR TITLE
db: add `source` to tracks table to allow per-source watermarking

### DIFF
--- a/cmd/handlers.go
+++ b/cmd/handlers.go
@@ -512,7 +512,7 @@ func apiSubmitListensHandler(database *db.DB, atprotoService *atprotoauth.AuthSe
 			}
 
 			// Skip listens we already stored so client retries stay idempotent
-			exists, err := database.HasTrackListen(userID, track.Name, track.Timestamp)
+			exists, err := database.HasTrackListen(userID, db.SourceListenBrainz, track.Name, track.Timestamp)
 			if err != nil {
 				log.Printf("apiSubmitListensHandler: Error checking for existing listen for user %d: %v", userID, err)
 			} else if exists {

--- a/cmd/handlers.go
+++ b/cmd/handlers.go
@@ -422,7 +422,7 @@ func apiAppleMusicUnlink(database *db.DB) http.HandlerFunc {
 	}
 }
 
-// apiSubmitListensHandler handles ListenBrainz-compatible submissions
+// apiSubmitListensHandler handles ListenBrainz-compatible submissions.
 func apiSubmitListensHandler(database *db.DB, atprotoService *atprotoauth.AuthService, playingNowService *playingnow.Service, mbService *musicbrainz.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		userID, authenticated := session.GetUserID(r.Context())
@@ -521,7 +521,7 @@ func apiSubmitListensHandler(database *db.DB, atprotoService *atprotoauth.AuthSe
 			}
 
 			// Store the track
-			trackID, err := database.SaveTrack(userID, &track)
+			trackID, err := database.SaveTrack(userID, db.SourceListenBrainz, &track)
 			if err != nil {
 				log.Printf("apiSubmitListensHandler: Error saving track for user %d: %v", userID, err)
 				errors = append(errors, fmt.Sprintf("payload[%d]: failed to save track", i))
@@ -582,7 +582,7 @@ func hydrateAndSubmitListens(database *db.DB, atprotoService *atprotoauth.AuthSe
 				log.Printf("apiSubmitListensHandler: Could not hydrate track with MusicBrainz for user %d: %v (continuing with original data)", userID, err)
 			} else if hydratedTrack != nil {
 				track = *hydratedTrack
-				if err := database.UpdateTrack(saved.trackID, &track); err != nil {
+				if err := database.UpdateTrack(saved.trackID, db.SourceListenBrainz, &track); err != nil {
 					log.Printf("apiSubmitListensHandler: Error updating hydrated track for user %d: %v", userID, err)
 				}
 			}

--- a/db/db.go
+++ b/db/db.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -166,6 +167,78 @@ func (db *DB) Initialize() error {
 		return err
 	}
 
+	// source marks the scrobble source.
+	// Allows using the tracks table for watermarking plays without racing between sources
+	_, err = db.Exec(`ALTER TABLE tracks ADD COLUMN source TEXT`)
+	if err != nil && !strings.Contains(err.Error(), "duplicate column") {
+		return err
+	}
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_tracks_user_source_timestamp ON tracks(user_id, source, timestamp DESC)`); err != nil {
+		return err
+	}
+
+	return db.backfillTrackSources()
+}
+
+// TrackSource identifies the integration that wrote a track row.
+type TrackSource string
+
+const (
+	SourceAppleMusic   TrackSource = "applemusic"
+	SourceLastfm       TrackSource = "lastfm"
+	SourceSpotify      TrackSource = "spotify"
+	SourceListenBrainz TrackSource = "listenbrainz"
+
+	externalSource TrackSource = "external"
+)
+
+func (s TrackSource) IsValid() bool {
+	switch s {
+	case SourceAppleMusic, SourceLastfm, SourceSpotify, SourceListenBrainz:
+		return true
+	default:
+		return false
+	}
+}
+
+// Maps historical service_base_url values to their source. Remaining
+// non-empty presentations are ListenBrainz by elimination.
+var legacyIdentityByPresentation = []struct {
+	presentation string
+	source       TrackSource
+}{
+	{"music.apple.com", SourceAppleMusic},
+	{"last.fm", SourceLastfm},
+	{"open.spotify.com", SourceSpotify},
+	{"listenbrainz", SourceListenBrainz},
+	{"spotify", SourceListenBrainz},
+}
+
+func (db *DB) backfillTrackSources() error {
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("backfilling track sources: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.Exec(`UPDATE tracks SET source = ? WHERE source IS NULL`, externalSource); err != nil {
+		return fmt.Errorf("backfilling track sources: %w", err)
+	}
+	for _, mapping := range legacyIdentityByPresentation {
+		if _, err := tx.Exec(
+			`UPDATE tracks SET source = ? WHERE source = ? AND service_base_url = ?`,
+			mapping.source, externalSource, mapping.presentation); err != nil {
+			return fmt.Errorf("backfilling track sources for %s: %w", mapping.source, err)
+		}
+	}
+	if _, err := tx.Exec(
+		`UPDATE tracks SET source = ? WHERE source = ? AND service_base_url IS NOT NULL AND service_base_url != ''`,
+		SourceListenBrainz, externalSource); err != nil {
+		return fmt.Errorf("backfilling remaining listenbrainz sources: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("backfilling track sources: %w", err)
+	}
 	return nil
 }
 
@@ -355,8 +428,11 @@ func (db *DB) GetAllAppleMusicLinkedUsers() ([]*models.User, error) {
 	return users, nil
 }
 
-func (db *DB) SaveTrack(userID int64, track *models.Track) (int64, error) {
-	// marshal artist json
+func (db *DB) SaveTrack(userID int64, source TrackSource, track *models.Track) (int64, error) {
+	if !source.IsValid() {
+		return 0, fmt.Errorf("invalid source %q", source)
+	}
+
 	artistString := ""
 	if len(track.Artist) > 0 {
 		bytes, err := json.Marshal(track.Artist)
@@ -370,11 +446,11 @@ func (db *DB) SaveTrack(userID int64, track *models.Track) (int64, error) {
 	var trackID int64
 
 	err := db.QueryRow(`
-	INSERT INTO tracks (user_id, name, recording_mbid, artist, album, release_mbid, url, timestamp, duration_ms, progress_ms, service_base_url, isrc, has_stamped)
-	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	INSERT INTO tracks (user_id, name, recording_mbid, artist, album, release_mbid, url, timestamp, duration_ms, progress_ms, service_base_url, isrc, has_stamped, source)
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	RETURNING id`,
 		userID, track.Name, track.RecordingMBID, artistString, track.Album, track.ReleaseMBID, track.URL, track.Timestamp,
-		track.DurationMs, track.ProgressMs, track.ServiceBaseUrl, track.ISRC, track.HasStamped).Scan(&trackID)
+		track.DurationMs, track.ProgressMs, track.ServiceBaseUrl, track.ISRC, track.HasStamped, source).Scan(&trackID)
 
 	return trackID, err
 }
@@ -390,8 +466,11 @@ func (db *DB) HasTrackListen(userID int64, name string, timestamp time.Time) (bo
 	return exists, err
 }
 
-func (db *DB) UpdateTrack(trackID int64, track *models.Track) error {
-	// marshal artist json
+func (db *DB) UpdateTrack(trackID int64, source TrackSource, track *models.Track) error {
+	if !source.IsValid() {
+		return fmt.Errorf("invalid source %q", source)
+	}
+
 	artistString := ""
 	if len(track.Artist) > 0 {
 		bytes, err := json.Marshal(track.Artist)
@@ -402,7 +481,7 @@ func (db *DB) UpdateTrack(trackID int64, track *models.Track) error {
 		artistString = string(bytes)
 	}
 
-	_, err := db.Exec(`
+	res, err := db.Exec(`
 	UPDATE tracks
 	SET name = ?,
 	    recording_mbid = ?,
@@ -416,12 +495,24 @@ func (db *DB) UpdateTrack(trackID int64, track *models.Track) error {
 		service_base_url = ?,
 		isrc = ?,
 		has_stamped = ?
-	WHERE id = ?`,
+	WHERE id = ? AND source = ?`,
 		track.Name, track.RecordingMBID, artistString, track.Album, track.ReleaseMBID, track.URL, track.Timestamp,
 		track.DurationMs, track.ProgressMs, track.ServiceBaseUrl, track.ISRC, track.HasStamped,
-		trackID)
+		trackID, source)
+	if err != nil {
+		return fmt.Errorf("updating track %d: %w", trackID, err)
+	}
 
-	return err
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("updating track %d: %w", trackID, err)
+	}
+
+	if n == 0 {
+		return fmt.Errorf("track %d not found for source %s", trackID, source)
+	}
+
+	return nil
 }
 
 func (db *DB) GetRecentTracks(userID int64, limit int) ([]*models.Track, error) {
@@ -445,40 +536,77 @@ func (db *DB) GetRecentTracks(userID int64, limit int) ([]*models.Track, error) 
 	var tracks []*models.Track
 
 	for rows.Next() {
-		var artistString string
-		track := &models.Track{}
-		err := rows.Scan(
-			&track.PlayID,
-			&track.Name,
-			&track.RecordingMBID, // Scan new field
-			&artistString,        // scan to be unmarshaled later
-			&track.Album,
-			&track.ReleaseMBID, // Scan new field
-			&track.URL,
-			&track.Timestamp,
-			&track.DurationMs,
-			&track.ProgressMs,
-			&track.ServiceBaseUrl,
-			&track.ISRC,
-			&track.HasStamped,
-		)
-
+		track, err := scanTrack(rows)
 		if err != nil {
 			return nil, err
 		}
 
-		// unmarshal artist json
-		var artists []models.Artist
-		err = json.Unmarshal([]byte(artistString), &artists)
-		if err != nil {
-			// fallback to previous format
-			artists = []models.Artist{{Name: artistString}}
-		}
-		track.Artist = artists
 		tracks = append(tracks, track)
 	}
 
-	return tracks, nil
+	return tracks, rows.Err()
+}
+
+// rowScanner matches *sql.Row and *sql.Rows.
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+// scanTrack scans one tracks-table row into a models.Track.
+func scanTrack(row rowScanner) (*models.Track, error) {
+	var (
+		artistString string
+		track        models.Track
+	)
+	if err := row.Scan(
+		&track.PlayID,
+		&track.Name,
+		&track.RecordingMBID,
+		&artistString,
+		&track.Album,
+		&track.ReleaseMBID,
+		&track.URL,
+		&track.Timestamp,
+		&track.DurationMs,
+		&track.ProgressMs,
+		&track.ServiceBaseUrl,
+		&track.ISRC,
+		&track.HasStamped,
+	); err != nil {
+		return nil, err
+	}
+
+	var artists []models.Artist
+	if err := json.Unmarshal([]byte(artistString), &artists); err != nil {
+		// fallback to previous format
+		artists = []models.Artist{{Name: artistString}}
+	}
+
+	track.Artist = artists
+
+	return &track, nil
+}
+
+func (db *DB) GetLatestTrackForService(userID int64, source TrackSource) (*models.Track, error) {
+	if !source.IsValid() {
+		return nil, fmt.Errorf("invalid source %q", source)
+	}
+
+	track, err := scanTrack(db.QueryRow(`
+    SELECT id, name, recording_mbid, artist, album, release_mbid, url, timestamp, duration_ms, progress_ms, service_base_url, isrc, has_stamped
+    FROM tracks
+    WHERE user_id = ? AND source = ?
+    ORDER BY timestamp DESC
+    LIMIT 1`, userID, source))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to query latest %s track for user %d: %w", source, userID, err)
+	}
+
+	return track, nil
 }
 
 // SpotifyQueryMapping maps Spotify sql query results to user structs
@@ -631,20 +759,24 @@ func (db *DB) DebugViewUserInformation(userID int64) (map[string]any, error) {
 	return resultMap, nil
 }
 
-func (db *DB) GetLastKnownTimestamp(userID int64) (*time.Time, error) {
+func (db *DB) GetLastKnownTimestamp(userID int64, source TrackSource) (*time.Time, error) {
+	if !source.IsValid() {
+		return nil, fmt.Errorf("invalid source %q", source)
+	}
+
 	var lastTimestamp time.Time
 	err := db.QueryRow(`
 		SELECT timestamp
 		FROM tracks
-		WHERE user_id = ?
+		WHERE user_id = ? AND source = ?
 		ORDER BY timestamp DESC
-		LIMIT 1`, userID).Scan(&lastTimestamp)
+		LIMIT 1`, userID, source).Scan(&lastTimestamp)
 
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to query last scrobble timestamp for user %d: %w", userID, err)
+		return nil, fmt.Errorf("failed to query last track timestamp for user %d: %w", userID, err)
 	}
 
 	return &lastTimestamp, nil

--- a/db/db.go
+++ b/db/db.go
@@ -209,6 +209,7 @@ var legacyIdentityByPresentation = []struct {
 }{
 	{"music.apple.com", SourceAppleMusic},
 	{"last.fm", SourceLastfm},
+	{"lastfm", SourceLastfm},
 	{"open.spotify.com", SourceSpotify},
 	{"listenbrainz", SourceListenBrainz},
 	{"spotify", SourceListenBrainz},
@@ -231,11 +232,7 @@ func (db *DB) backfillTrackSources() error {
 			return fmt.Errorf("backfilling track sources for %s: %w", mapping.source, err)
 		}
 	}
-	if _, err := tx.Exec(
-		`UPDATE tracks SET source = ? WHERE source = ? AND service_base_url IS NOT NULL AND service_base_url != ''`,
-		SourceListenBrainz, externalSource); err != nil {
-		return fmt.Errorf("backfilling remaining listenbrainz sources: %w", err)
-	}
+
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("backfilling track sources: %w", err)
 	}
@@ -457,12 +454,15 @@ func (db *DB) SaveTrack(userID int64, source TrackSource, track *models.Track) (
 
 // HasTrackListen reports whether a listen with the same name and timestamp
 // is already stored for the user, so resubmitted payloads stay idempotent.
-func (db *DB) HasTrackListen(userID int64, name string, timestamp time.Time) (bool, error) {
+func (db *DB) HasTrackListen(userID int64, source TrackSource, name string, timestamp time.Time) (bool, error) {
+	if !source.IsValid() {
+		return false, fmt.Errorf("invalid source %q", source)
+	}
 	var exists bool
 	err := db.QueryRow(`
 	SELECT EXISTS(
-		SELECT 1 FROM tracks WHERE user_id = ? AND name = ? AND timestamp = ?
-	)`, userID, name, timestamp).Scan(&exists)
+		SELECT 1 FROM tracks WHERE user_id = ? AND source = ? AND name = ? AND timestamp = ?
+	)`, userID, source, name, timestamp).Scan(&exists)
 	return exists, err
 }
 

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -306,7 +306,8 @@ func TestCursorsTimestampScopesToSource(t *testing.T) {
 	if err != nil {
 		t.Fatalf("timestamp: %v", err)
 	}
-	if got == nil || got.Before(at) {
-		t.Fatalf("got %v want >= %v", got, at)
+	want := base.Add(-5 * time.Minute)
+	if got == nil || !got.Equal(want) {
+		t.Fatalf("got %v want %v", got, want)
 	}
 }

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -1,0 +1,311 @@
+package db
+
+import (
+	"testing"
+	"time"
+
+	"github.com/teal-fm/piper/models"
+)
+
+func newTestDB(t *testing.T) *DB {
+	t.Helper()
+	db, err := New(":memory:")
+	if err != nil {
+		t.Fatalf("new db: %v", err)
+	}
+	if err := db.Initialize(); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func createTestUser(t *testing.T, db *DB) int64 {
+	t.Helper()
+	id, err := db.CreateUser(&models.User{})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	return id
+}
+
+func saveTrack(t *testing.T, db *DB, userID int64, url string, source TrackSource, presentation string, at time.Time) {
+	t.Helper()
+	_, err := db.SaveTrack(userID, source, &models.Track{
+		Name:           "Test Track",
+		Artist:         []models.Artist{{Name: "Test Artist"}},
+		URL:            url,
+		ServiceBaseUrl: presentation,
+		Timestamp:      at,
+	})
+	if err != nil {
+		t.Fatalf("save track: %v", err)
+	}
+}
+
+func TestBackfill(t *testing.T) {
+	db := newTestDB(t)
+	uid := createTestUser(t, db)
+	cases := []struct {
+		name       string
+		present    string
+		wantSource string
+	}{
+		{"apple", "music.apple.com", string(SourceAppleMusic)},
+		{"lastfm", "last.fm", string(SourceLastfm)},
+		{"spotify", "open.spotify.com", string(SourceSpotify)},
+		{"listenbrainz default", "listenbrainz", string(SourceListenBrainz)},
+		{"listenbrainz spotify id", "spotify", string(SourceListenBrainz)},
+		{"arbitrary", "Tidal Music App", string(SourceListenBrainz)},
+		{"empty", "", string(externalSource)},
+	}
+	for _, tc := range cases {
+		_, err := db.Exec(`INSERT INTO tracks (user_id, name, artist, album, url, timestamp, service_base_url) VALUES (?, 'Seed','[]','',?, ?, ?)`, uid, "seeded/"+tc.present, time.Now().UTC(), tc.present)
+		if err != nil {
+			t.Fatalf("seed %s: %v", tc.name, err)
+		}
+	}
+	if err := db.backfillTrackSources(); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got string
+			if err := db.QueryRow(`SELECT source FROM tracks WHERE user_id=? AND url=?`, uid, "seeded/"+tc.present).Scan(&got); err != nil {
+				t.Fatalf("load: %v", err)
+			}
+			if got != tc.wantSource {
+				t.Errorf("got %q want %q", got, tc.wantSource)
+			}
+		})
+	}
+}
+
+func TestSaveTrack(t *testing.T) {
+	db := newTestDB(t)
+	uid := createTestUser(t, db)
+	cases := []struct {
+		name    string
+		source  TrackSource
+		present string
+	}{
+		{"apple", SourceAppleMusic, "music.apple.com"},
+		{"lastfm", SourceLastfm, "last.fm"},
+		{"listenbrainz spoof apple", SourceListenBrainz, "music.apple.com"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			url := "save/" + tc.name
+			_, err := db.SaveTrack(uid, tc.source, &models.Track{
+				Name:           "Persist",
+				Artist:         []models.Artist{{Name: "Artist"}},
+				URL:            url,
+				ServiceBaseUrl: tc.present,
+				Timestamp:      time.Now().UTC(),
+			})
+			if err != nil {
+				t.Fatalf("want ok got %v", err)
+			}
+			var gotSource, gotPresent string
+			if err := db.QueryRow(`SELECT source, service_base_url FROM tracks WHERE user_id=? AND url=?`, uid, url).Scan(&gotSource, &gotPresent); err != nil {
+				t.Fatalf("load: %v", err)
+			}
+			if gotSource != string(tc.source) || gotPresent != tc.present {
+				t.Errorf("got %q/%q want %q/%q", gotSource, gotPresent, tc.source, tc.present)
+			}
+		})
+	}
+}
+
+func TestSaveTrackRejectsInvalidSource(t *testing.T) {
+	db := newTestDB(t)
+	uid := createTestUser(t, db)
+	cases := []struct {
+		name   string
+		source TrackSource
+	}{
+		{"empty", TrackSource("")},
+		{"external", externalSource},
+		{"unknown", TrackSource("banana")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := db.SaveTrack(uid, tc.source, &models.Track{
+				Name:      "Persist",
+				Artist:    []models.Artist{{Name: "Artist"}},
+				URL:       "save/" + tc.name,
+				Timestamp: time.Now().UTC(),
+			})
+			if err == nil {
+				t.Fatal("want error")
+			}
+		})
+	}
+}
+
+func TestUpdateTrack(t *testing.T) {
+	db := newTestDB(t)
+	uid := createTestUser(t, db)
+	url := "upd/owner" + time.Now().Format(time.RFC3339Nano)
+	id, err := db.SaveTrack(uid, SourceLastfm, &models.Track{
+		Name:      "Original",
+		Artist:    []models.Artist{{Name: "Artist"}},
+		URL:       url,
+		Timestamp: time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := db.UpdateTrack(id, SourceLastfm, &models.Track{
+		Name:      "Clobbered",
+		Artist:    []models.Artist{{Name: "Artist"}},
+		URL:       url,
+		Timestamp: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("want ok got %v", err)
+	}
+	var got string
+	if err := db.QueryRow(`SELECT name FROM tracks WHERE id=?`, id).Scan(&got); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got != "Clobbered" {
+		t.Errorf("got %q want %q", got, "Clobbered")
+	}
+}
+
+func TestUpdateTrackRejectsForeignOrInvalidSource(t *testing.T) {
+	db := newTestDB(t)
+	uid := createTestUser(t, db)
+	cases := []struct {
+		name     string
+		updateAs TrackSource
+	}{
+		{"foreign", SourceAppleMusic},
+		{"invalid", TrackSource("")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			url := "upd/" + tc.name + time.Now().Format(time.RFC3339Nano)
+			id, err := db.SaveTrack(uid, SourceLastfm, &models.Track{
+				Name:      "Original",
+				Artist:    []models.Artist{{Name: "Artist"}},
+				URL:       url,
+				Timestamp: time.Now().UTC(),
+			})
+			if err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+			if err := db.UpdateTrack(id, tc.updateAs, &models.Track{
+				Name:      "Clobbered",
+				Artist:    []models.Artist{{Name: "Artist"}},
+				URL:       url,
+				Timestamp: time.Now().UTC(),
+			}); err == nil {
+				t.Fatal("want error")
+			}
+			var got string
+			if err := db.QueryRow(`SELECT name FROM tracks WHERE id=?`, id).Scan(&got); err != nil {
+				t.Fatalf("load: %v", err)
+			}
+			if got != "Original" {
+				t.Errorf("got %q want %q", got, "Original")
+			}
+		})
+	}
+	t.Run("unknown id", func(t *testing.T) {
+		if err := db.UpdateTrack(9999, SourceLastfm, &models.Track{Name: "Ghost", Artist: []models.Artist{{Name: "A"}}, Timestamp: time.Now().UTC()}); err == nil {
+			t.Fatal("want error")
+		}
+	})
+}
+
+func TestCursors(t *testing.T) {
+	db := newTestDB(t)
+	uid := createTestUser(t, db)
+	base := time.Now().UTC()
+
+	saveTrack(t, db, uid, "https://music.apple.com/us/song/old/1", SourceAppleMusic, "music.apple.com", base.Add(-10*time.Minute))
+	saveTrack(t, db, uid, "https://www.last.fm/music/_/New", SourceLastfm, "last.fm", base.Add(-5*time.Minute))
+	saveTrack(t, db, uid, "https://music.apple.com/us/song/new/2", SourceAppleMusic, "music.apple.com", base.Add(-1*time.Minute))
+	saveTrack(t, db, uid, "https://music.apple.com/us/song/spoofed/2", SourceListenBrainz, "music.apple.com", base.Add(-30*time.Second))
+
+	cases := []struct {
+		name    string
+		source  TrackSource
+		wantURL string
+	}{
+		{"apple newest", SourceAppleMusic, "https://music.apple.com/us/song/new/2"},
+		{"lastfm only", SourceLastfm, "https://www.last.fm/music/_/New"},
+		{"spoof does not leak into apple cursor", SourceAppleMusic, "https://music.apple.com/us/song/new/2"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := db.GetLatestTrackForService(uid, tc.source)
+			if err != nil {
+				t.Fatalf("GetLatest: %v", err)
+			}
+			if got == nil || got.URL != tc.wantURL {
+				t.Fatalf("got %v want %q", got, tc.wantURL)
+			}
+		})
+	}
+}
+
+func TestCursorsEmpty(t *testing.T) {
+	db := newTestDB(t)
+	uid := createTestUser(t, db)
+	got, err := db.GetLatestTrackForService(uid, SourceAppleMusic)
+	if err != nil {
+		t.Fatalf("want ok got %v", err)
+	}
+	if got != nil {
+		t.Fatalf("want nil got %v", got)
+	}
+	if ts, err := db.GetLastKnownTimestamp(uid, SourceAppleMusic); err != nil || ts != nil {
+		t.Fatalf("want nil timestamp got %v err %v", ts, err)
+	}
+}
+
+func TestCursorsRejectsInvalidSource(t *testing.T) {
+	db := newTestDB(t)
+	uid := createTestUser(t, db)
+	base := time.Now().UTC()
+	saveTrack(t, db, uid, "https://music.apple.com/us/song/new/2", SourceAppleMusic, "music.apple.com", base)
+
+	cases := []struct {
+		name   string
+		source TrackSource
+	}{
+		{"empty", TrackSource("")},
+		{"external", externalSource},
+		{"unknown", TrackSource("banana")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := db.GetLatestTrackForService(uid, tc.source); err == nil {
+				t.Fatal("want error")
+			}
+			if _, err := db.GetLastKnownTimestamp(uid, tc.source); err == nil {
+				t.Fatal("want error")
+			}
+		})
+	}
+}
+
+func TestCursorsTimestampScopesToSource(t *testing.T) {
+	db := newTestDB(t)
+	uid := createTestUser(t, db)
+	base := time.Now().UTC()
+	saveTrack(t, db, uid, "https://music.apple.com/us/song/new/2", SourceAppleMusic, "music.apple.com", base.Add(-1*time.Minute))
+	saveTrack(t, db, uid, "https://www.last.fm/music/_/New", SourceLastfm, "last.fm", base.Add(-5*time.Minute))
+
+	at := base.Add(-20 * time.Minute)
+	saveTrack(t, db, uid, "https://www.last.fm/music/_/Old", SourceLastfm, "last.fm", at)
+	got, err := db.GetLastKnownTimestamp(uid, SourceLastfm)
+	if err != nil {
+		t.Fatalf("timestamp: %v", err)
+	}
+	if got == nil || got.Before(at) {
+		t.Fatalf("got %v want >= %v", got, at)
+	}
+}

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -52,11 +52,12 @@ func TestBackfill(t *testing.T) {
 		wantSource string
 	}{
 		{"apple", "music.apple.com", string(SourceAppleMusic)},
-		{"lastfm", "last.fm", string(SourceLastfm)},
+		{"lastfm dot", "last.fm", string(SourceLastfm)},
+		{"lastfm bare", "lastfm", string(SourceLastfm)},
 		{"spotify", "open.spotify.com", string(SourceSpotify)},
 		{"listenbrainz default", "listenbrainz", string(SourceListenBrainz)},
 		{"listenbrainz spotify id", "spotify", string(SourceListenBrainz)},
-		{"arbitrary", "Tidal Music App", string(SourceListenBrainz)},
+		{"arbitrary", "Tidal Music App", string(externalSource)},
 		{"empty", "", string(externalSource)},
 	}
 	for _, tc := range cases {

--- a/service/applemusic/applemusic.go
+++ b/service/applemusic/applemusic.go
@@ -567,10 +567,9 @@ func (s *Service) ProcessUser(ctx context.Context, user *models.User) error {
 		return nil
 	}
 
-	// Get the last saved track to compare PlayParams.id
-	lastTracks, err := s.DB.GetRecentTracks(user.ID, 1)
+	lastTrack, err := s.DB.GetLatestTrackForService(user.ID, db.SourceAppleMusic)
 	if err != nil {
-		s.logger.Printf("failed to get last tracks for user %d: %v", user.ID, err)
+		s.logger.Printf("failed to get last apple music track for user %d: %v", user.ID, err)
 	}
 
 	// Pre-compute the hash for uploaded tracks so comparisons against stored
@@ -581,12 +580,9 @@ func (s *Service) ProcessUser(ctx context.Context, user *models.User) error {
 	}
 
 	// Check if this is a new track (by URL / upload hash)
-	if len(lastTracks) > 0 {
-		lastTrack := lastTracks[0]
-		if lastTrack.URL == currentURL {
-			s.logger.Printf("track unchanged for user %d: %s by %s", user.ID, currentAppleTrack.Attributes.Name, currentAppleTrack.Attributes.ArtistName)
-			return nil
-		}
+	if lastTrack != nil && lastTrack.URL == currentURL {
+		s.logger.Printf("track unchanged for user %d: %s by %s", user.ID, currentAppleTrack.Attributes.Name, currentAppleTrack.Attributes.ArtistName)
+		return nil
 	}
 
 	// Convert to internal track format
@@ -599,7 +595,7 @@ func (s *Service) ProcessUser(ctx context.Context, user *models.User) error {
 	// Hydration is handled in toTrack() using MusicBrainz search; no ISRC-only hydration here
 
 	// Save the new track
-	if _, err := s.DB.SaveTrack(user.ID, track); err != nil {
+	if _, err := s.DB.SaveTrack(user.ID, db.SourceAppleMusic, track); err != nil {
 		s.logger.Printf("failed saving apple track for user %d: %v", user.ID, err)
 		return err
 	}

--- a/service/applemusic/applemusic_test.go
+++ b/service/applemusic/applemusic_test.go
@@ -142,11 +142,12 @@ func newProcessUserTestEnv(t *testing.T, apiResponse string) *processUserTestEnv
 func (env *processUserTestEnv) seedUploadedTrack(t *testing.T, name, artist, album string) {
 	t.Helper()
 	hash := generateUploadHash(makeTestTrack(name, album, artist))
-	_, err := env.testDB.SaveTrack(env.user.ID, &models.Track{
-		Name:   name,
-		Artist: []models.Artist{{Name: artist}},
-		Album:  album,
-		URL:    hash,
+	_, err := env.testDB.SaveTrack(env.user.ID, db.SourceAppleMusic, &models.Track{
+		Name:           name,
+		Artist:         []models.Artist{{Name: artist}},
+		Album:          album,
+		URL:            hash,
+		ServiceBaseUrl: "music.apple.com",
 	})
 	if err != nil {
 		t.Fatalf("failed to seed track: %v", err)

--- a/service/lastfm/lastfm.go
+++ b/service/lastfm/lastfm.go
@@ -126,7 +126,7 @@ func (l *Service) getRecentTracks(ctx context.Context, username string) (*Recent
 		return nil, fmt.Errorf("failed to get user ID for %s: %w", username, err)
 	}
 
-	lastKnownTimestamp, err := l.db.GetLastKnownTimestamp(user.ID)
+	lastKnownTimestamp, err := l.db.GetLastKnownTimestamp(user.ID, db.SourceLastfm)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get last scrobble timestamp for %s: %w", username, err)
 	}
@@ -319,7 +319,7 @@ func (l *Service) processTracks(ctx context.Context, username string, tracks []T
 		return fmt.Errorf("failed to get user ID for %s: %w", username, err)
 	}
 
-	lastKnownTimestamp, err := l.db.GetLastKnownTimestamp(user.ID)
+	lastKnownTimestamp, err := l.db.GetLastKnownTimestamp(user.ID, db.SourceLastfm)
 	if err != nil {
 		return fmt.Errorf("failed to get last scrobble timestamp for %s: %w", username, err)
 	}
@@ -431,7 +431,7 @@ func (l *Service) processTracks(ctx context.Context, username string, tracks []T
 			// we can use the track without MBIDs, it's still valid
 			hydratedTrack = &baseTrack
 		}
-		_, err = l.db.SaveTrack(user.ID, hydratedTrack)
+		_, err = l.db.SaveTrack(user.ID, db.SourceLastfm, hydratedTrack)
 		if err != nil {
 			return err
 		}

--- a/service/spotify/spotify.go
+++ b/service/spotify/spotify.go
@@ -799,7 +799,7 @@ func (s *Service) stampTrack(ctx context.Context, userID int64, track *models.Tr
 	}
 
 	// Save the track now that it is stamped and hydrated
-	if _, err := s.DB.SaveTrack(userID, trackToSubmit); err != nil {
+	if _, err := s.DB.SaveTrack(userID, db.SourceSpotify, trackToSubmit); err != nil {
 		s.logger.Printf("Error saving track for user %d: %v", userID, err)
 		return
 	}

--- a/service/spotify/spotify_test.go
+++ b/service/spotify/spotify_test.go
@@ -795,10 +795,10 @@ func TestHandleTrackHistory(t *testing.T) {
 		track1 := createTestTrack("Track 1", "Artist 1", "http://spotify/track1", 180000, 0)
 		track2 := createTestTrack("Track 2", "Artist 2", "http://spotify/track2", 200000, 0)
 
-		if _, err := database.SaveTrack(userID, track1); err != nil {
+		if _, err := database.SaveTrack(userID, db.SourceSpotify, track1); err != nil {
 			t.Fatalf("Failed to save track1: %v", err)
 		}
-		if _, err := database.SaveTrack(userID, track2); err != nil {
+		if _, err := database.SaveTrack(userID, db.SourceSpotify, track2); err != nil {
 			t.Fatalf("Failed to save track2: %v", err)
 		}
 


### PR DESCRIPTION
When a source (spotify, lfm, listenbrainz) scrobbles, it needs to read it's own tracks to be able to correctly know whether this track is new or not (either by timestamp or recency).

There was no easy way of doing that except actually embedding a `source` in the db. We could have ran widlcard on the `service_base_url` but it can be faked by listenbrainz / manual uploads and isn't guaranteed to be stable, it's also fairly slow.

Using an in-memory datastructure like spotify does is prone to the same kind of bugs but on-restart. It would have been simpler but still buggy. This should fix cross-source contamination forever

Now, all the sources reach for only their own tracks, while the readers keep reading without being bothered by sources.

I'm not super keen on the name `source`. `service` sounds better but I didn't want to conflict with the `base_url` field. `provider` also works but is vague.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Track history is now separated by music service, improving accuracy for recent plays, duplicate detection, and timestamps.
  - New tracks and updates record their originating service.
  - Existing track records are automatically assigned to the appropriate service.

- **Bug Fixes**
  - Prevented activity from one service from affecting another service’s history.
  - Improved handling of legacy track records and artist information.
  - Added validation to prevent invalid or mismatched service updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->