### PR TITLE
feat: Handle failures getting auth token from Spotify

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -367,6 +367,19 @@ func (db *DB) UpdateUserToken(userID int64, accessToken, refreshToken string, ex
 	return err
 }
 
+// ClearUserSpotifyTokens removes the stored Spotify tokens for a user, so
+// queries that look for usable tokens skip them.
+func (db *DB) ClearUserSpotifyTokens(userID int64) error {
+	now := time.Now().UTC()
+	_, err := db.Exec(`
+	UPDATE users
+	SET access_token = NULL, refresh_token = NULL, token_expiry = NULL, updated_at = ?
+	WHERE id = ?`,
+		now, userID)
+
+	return err
+}
+
 func (db *DB) UpdateAppleMusicUserToken(userID int64, userToken string) error {
 	now := time.Now().UTC()
 	_, err := db.Exec(`
@@ -633,7 +646,7 @@ func (db *DB) GetUsersWithExpiredTokens() ([]*models.User, error) {
 	rows, err := db.Query(`
     SELECT id, username, email, spotify_id, access_token, refresh_token, token_expiry, created_at, updated_at
     FROM users
-    WHERE refresh_token IS NOT NULL AND token_expiry < ?
+    WHERE refresh_token IS NOT NULL AND refresh_token != '' AND token_expiry < ?
     ORDER BY id`, time.Now().UTC())
 
 	if err != nil {

--- a/service/spotify/spotify.go
+++ b/service/spotify/spotify.go
@@ -333,7 +333,7 @@ func (s *Service) refreshTokenForUser(user *models.User) (string, error) {
 // isRefreshTokenRejected reports whether Spotify permanently rejected the
 // refresh token, as opposed to failing for a transient reason.
 func isRefreshTokenRejected(statusCode int, body []byte) bool {
-	if statusCode != http.StatusBadRequest && statusCode != http.StatusUnauthorized {
+	if statusCode != http.StatusBadRequest {
 		return false
 	}
 

--- a/service/spotify/spotify.go
+++ b/service/spotify/spotify.go
@@ -288,7 +288,7 @@ func (s *Service) refreshTokenForUser(user *models.User) (string, error) {
 
 		// Only discard the refresh token when Spotify says it is genuinely dead.
 		if isRefreshTokenRejected(resp.StatusCode, body) {
-			if updateErr := s.DB.UpdateUserToken(userID, "", "", time.Now().UTC()); updateErr != nil {
+			if updateErr := s.DB.ClearUserSpotifyTokens(userID); updateErr != nil {
 				s.logger.Printf("Failed to clear bad refresh token for user %d: %v", userID, updateErr)
 			}
 			return "", fmt.Errorf("spotify refresh token rejected for user %d (%d): %s", userID, resp.StatusCode, string(body))

--- a/service/spotify/spotify.go
+++ b/service/spotify/spotify.go
@@ -285,11 +285,15 @@ func (s *Service) refreshTokenForUser(user *models.User) (string, error) {
 		s.mu.Lock()
 		delete(s.userTokens, userID)
 		s.mu.Unlock()
-		// Also clear the bad refresh token from the DB
-		updateErr := s.DB.UpdateUserToken(userID, "", "", time.Now().UTC()) // Clear tokens
-		if updateErr != nil {
-			s.logger.Printf("Failed to clear bad refresh token for user %d: %v", userID, updateErr)
+
+		// Only discard the refresh token when Spotify says it is genuinely dead.
+		if isRefreshTokenRejected(resp.StatusCode, body) {
+			if updateErr := s.DB.UpdateUserToken(userID, "", "", time.Now().UTC()); updateErr != nil {
+				s.logger.Printf("Failed to clear bad refresh token for user %d: %v", userID, updateErr)
+			}
+			return "", fmt.Errorf("spotify refresh token rejected for user %d (%d): %s", userID, resp.StatusCode, string(body))
 		}
+
 		return "", fmt.Errorf("spotify token refresh failed (%d): %s", resp.StatusCode, string(body))
 	}
 
@@ -324,6 +328,23 @@ func (s *Service) refreshTokenForUser(user *models.User) (string, error) {
 
 	s.logger.Printf("Successfully refreshed token for user %d", userID)
 	return tokenResponse.AccessToken, nil
+}
+
+// isRefreshTokenRejected reports whether Spotify permanently rejected the
+// refresh token, as opposed to failing for a transient reason.
+func isRefreshTokenRejected(statusCode int, body []byte) bool {
+	if statusCode != http.StatusBadRequest && statusCode != http.StatusUnauthorized {
+		return false
+	}
+
+	var errorResponse struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(body, &errorResponse); err != nil {
+		return false
+	}
+
+	return errorResponse.Error == "invalid_grant"
 }
 
 // RefreshToken attempts to refresh the token for a given user ID.

--- a/service/spotify/spotify_test.go
+++ b/service/spotify/spotify_test.go
@@ -1545,6 +1545,14 @@ func TestIsRefreshTokenRejected(t *testing.T) {
 			expected:   false,
 		},
 		{
+			// Spotify only documents the 400 for a dead token, so an
+			// invalid_grant under any other status stays retryable.
+			name:       "invalid_grant under an undocumented status",
+			statusCode: http.StatusUnauthorized,
+			body:       `{"error":"invalid_grant"}`,
+			expected:   false,
+		},
+		{
 			name:       "bad request with unparseable body",
 			statusCode: http.StatusBadRequest,
 			body:       "not json",

--- a/service/spotify/spotify_test.go
+++ b/service/spotify/spotify_test.go
@@ -1436,12 +1436,15 @@ func (s stubRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 func newRefreshTestService(t *testing.T, database *db.DB, statusCode int, body string) *Service {
 	t.Helper()
 
+	previousID := viper.Get("spotify.client_id")
+	previousSecret := viper.Get("spotify.client_secret")
+	t.Cleanup(func() {
+		viper.Set("spotify.client_id", previousID)
+		viper.Set("spotify.client_secret", previousSecret)
+	})
+
 	viper.Set("spotify.client_id", "id")
 	viper.Set("spotify.client_secret", "secret")
-	t.Cleanup(func() {
-		viper.Set("spotify.client_id", "")
-		viper.Set("spotify.client_secret", "")
-	})
 
 	service := newTestService(database, &mockPlayingNowService{})
 	service.httpClient = &http.Client{

--- a/service/spotify/spotify_test.go
+++ b/service/spotify/spotify_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/viper"
 	"github.com/teal-fm/piper/db"
 	"github.com/teal-fm/piper/models"
 	"github.com/teal-fm/piper/session"
@@ -1412,4 +1413,150 @@ func TestGenerateLocalHash(t *testing.T) {
 			t.Errorf("Expected different hashes for different albums, both got %s", hashA)
 		}
 	})
+}
+
+// ===== Token Refresh Tests =====
+
+// stubRoundTripper answers every request with a canned response, standing in
+// for accounts.spotify.com.
+type stubRoundTripper struct {
+	statusCode int
+	body       string
+}
+
+func (s stubRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: s.statusCode,
+		Body:       io.NopCloser(strings.NewReader(s.body)),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+func newRefreshTestService(t *testing.T, database *db.DB, statusCode int, body string) *Service {
+	t.Helper()
+
+	viper.Set("spotify.client_id", "id")
+	viper.Set("spotify.client_secret", "secret")
+	t.Cleanup(func() {
+		viper.Set("spotify.client_id", "")
+		viper.Set("spotify.client_secret", "")
+	})
+
+	service := newTestService(database, &mockPlayingNowService{})
+	service.httpClient = &http.Client{
+		Transport: stubRoundTripper{statusCode: statusCode, body: body},
+	}
+	return service
+}
+
+// A 502 from Spotify is transient -- we should keep the refresh token & retry later.
+func TestRefreshTokenForUser_TransientFailureKeepsRefreshToken(t *testing.T) {
+	database := setupTestDB(t)
+	userID := createTestUser(t, database)
+
+	user, err := database.AddSpotifySession(userID, "RUSH", "moving@pict.ures", "rush", "access", "refresh", time.Now().UTC().Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("Failed to link Spotify session: %v", err)
+	}
+
+	service := newRefreshTestService(t, database, http.StatusBadGateway, "<html><head><title>502 Server Error</title></head></html>")
+	service.userTokens[userID] = "access"
+
+	if _, err := service.refreshTokenForUser(user); err == nil {
+		t.Fatal("expected the refresh to fail")
+	}
+
+	reloaded, err := database.GetUserByID(userID)
+	if err != nil {
+		t.Fatalf("Failed to reload user: %v", err)
+	}
+	if reloaded.RefreshToken == nil || *reloaded.RefreshToken != "refresh" {
+		t.Errorf("RefreshToken = %v, want it kept for the next retry", reloaded.RefreshToken)
+	}
+
+	if _, exists := service.userTokens[userID]; exists {
+		t.Error("expected the stale cached access token to be dropped")
+	}
+}
+
+// A legitimately bad refresh token should clear the token from the DB.
+func TestRefreshTokenForUser_InvalidGrantClearsRefreshToken(t *testing.T) {
+	database := setupTestDB(t)
+	userID := createTestUser(t, database)
+
+	user, err := database.AddSpotifySession(userID, "YES", "close@to.the.edge", "yes", "access", "refresh", time.Now().UTC().Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("Failed to link Spotify session: %v", err)
+	}
+
+	service := newRefreshTestService(t, database, http.StatusBadRequest, `{"error":"invalid_grant","error_description":"Refresh token revoked"}`)
+	service.userTokens[userID] = "access"
+
+	if _, err := service.refreshTokenForUser(user); err == nil {
+		t.Fatal("expected the refresh to fail")
+	}
+
+	reloaded, err := database.GetUserByID(userID)
+	if err != nil {
+		t.Fatalf("Failed to reload user: %v", err)
+	}
+	if reloaded.RefreshToken != nil && *reloaded.RefreshToken != "" {
+		t.Errorf("RefreshToken = %v, want the dead token cleared", *reloaded.RefreshToken)
+	}
+}
+
+func TestIsRefreshTokenRejected(t *testing.T) {
+	testCases := []struct {
+		name       string
+		statusCode int
+		body       string
+		expected   bool
+	}{
+		{
+			name:       "revoked refresh token",
+			statusCode: http.StatusBadRequest,
+			body:       `{"error":"invalid_grant","error_description":"Refresh token revoked"}`,
+			expected:   true,
+		},
+		{
+			name:       "bad gateway HTML page",
+			statusCode: http.StatusBadGateway,
+			body:       "<html><head><title>502 Server Error</title></head></html>",
+			expected:   false,
+		},
+		{
+			name:       "service unavailable",
+			statusCode: http.StatusServiceUnavailable,
+			body:       "",
+			expected:   false,
+		},
+		{
+			name:       "rate limited",
+			statusCode: http.StatusTooManyRequests,
+			body:       `{"error":"too_many_requests"}`,
+			expected:   false,
+		},
+		{
+			// Our credentials are wrong, not the user's token.
+			name:       "client misconfigured",
+			statusCode: http.StatusUnauthorized,
+			body:       `{"error":"invalid_client"}`,
+			expected:   false,
+		},
+		{
+			name:       "bad request with unparseable body",
+			statusCode: http.StatusBadRequest,
+			body:       "not json",
+			expected:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isRefreshTokenRejected(tc.statusCode, []byte(tc.body)); got != tc.expected {
+				t.Errorf("isRefreshTokenRejected() = %v, want %v", got, tc.expected)
+			}
+		})
+	}
 }


### PR DESCRIPTION
This morning I noticed that Spotify briefly returned a 502 error when trying to refresh my access token:

```
2026/08/26 08:24:08 spotify: Error refreshing token for user 1: spotify token refresh failed (502):
<html><head>
<meta http-equiv="content-type" content="text/html;charset=utf-8">
<title>502 Server Error</title>
</head>
<body text=#000000 bgcolor=#ffffff>
<h1>Error: Server Error</h1>
<h2>The server encountered a temporary error and could not complete your request.<p>Please try again in 30 seconds.</h2>
<h2></h2>
</body></html>
2026/08/26 08:24:08 spotify: No users to fetch tracks for.
2026/08/26 08:24:28 spotify: Error refreshing token for user 1: no refresh token available for user 1
2026/08/26 08:24:28 spotify: No users to fetch tracks for.
2026/08/26 08:24:58 spotify: Error refreshing token for user 1: no refresh token available for user 1
2026/08/26 08:24:58 spotify: No users to fetch tracks for.
```

Piper interpreted this as the refresh token being invalid and revoked it — resulting in no more tracks being scrobbled from Piper until I logged back in and set the refresh token anew.

Spotify returns a 400 response with `{"error": "invalid_grant"}` when the access token has legitimately expired (i.e. after 6 months, now, woof); this 502 was transient and should have kept the refresh token around to continue scrobbling.

This fix makes sure that only Spotify's _real_ bad token scenario deletes the refresh token from the DB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Spotify authentication recovery after token-refresh failures.
  * Stale access tokens are now cleared after unsuccessful refresh attempts.
  * Persisted refresh tokens are retained for temporary failures and removed only when Spotify permanently rejects them.
  * Users with invalid or permanently rejected Spotify credentials are fully disconnected, preventing repeated failed refresh attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->