### PR TITLE
ci: Require submission agent version bump

### DIFF
--- a/.github/workflows/submission-agent-version.yaml
+++ b/.github/workflows/submission-agent-version.yaml
@@ -1,0 +1,81 @@
+name: Submission Agent Version
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  check-version:
+    name: Check version bump
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Require a higher submission agent version
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        shell: bash
+        run: |
+          changed_go_files=$(
+            git diff --name-only --diff-filter=ACDMRT "$BASE_SHA...HEAD" -- '*.go' |
+              grep -Ev '(_test\.go$|^cmd/(lexgen|musicbrainz-cli)/)' || true
+          )
+
+          if [[ -z "$changed_go_files" ]]; then
+            echo "No production Piper Go files changed. A version bump is not required."
+            exit 0
+          fi
+
+          echo "Production Piper Go files changed:"
+          printf '%s\n' "$changed_go_files" | sed 's/^/  /'
+
+          version_pattern='s/^[[:space:]]*const[[:space:]]+SubmissionAgent[[:space:]]*=[[:space:]]*"piper\/v([0-9]+\.[0-9]+\.[0-9]+)"[[:space:]]*$/\1/p'
+
+          base_version=$(git show "$BASE_SHA:models/constants.go" | sed -nE "$version_pattern")
+          current_version=$(sed -nE "$version_pattern" models/constants.go)
+
+          if [[ -z "$base_version" ]]; then
+            echo "Could not read SubmissionAgent from models/constants.go at $BASE_SHA."
+            exit 1
+          fi
+
+          if [[ -z "$current_version" ]]; then
+            echo 'SubmissionAgent must use the format "piper/vMAJOR.MINOR.PATCH" in models/constants.go.'
+            exit 1
+          fi
+
+          version_is_greater() {
+            local old_version=$1
+            local new_version=$2
+            local old_parts new_parts index
+
+            IFS=. read -r -a old_parts <<< "$old_version"
+            IFS=. read -r -a new_parts <<< "$new_version"
+
+            for index in 0 1 2; do
+              if ((10#${new_parts[index]} > 10#${old_parts[index]})); then
+                return 0
+              fi
+              if ((10#${new_parts[index]} < 10#${old_parts[index]})); then
+                return 1
+              fi
+            done
+
+            return 1
+          }
+
+          if ! version_is_greater "$base_version" "$current_version"; then
+            echo "SubmissionAgent must be bumped above piper/v$base_version."
+            echo "Current value: piper/v$current_version"
+            exit 1
+          fi
+
+          echo "SubmissionAgent increased from piper/v$base_version to piper/v$current_version."


### PR DESCRIPTION
## Summary

- Add a pull request workflow requiring a higher submission agent version when production Piper Go files change.
- Exclude tests and specified CLI commands from the version-bump requirement.
- Validate the `piper/vMAJOR.MINOR.PATCH` format and compare versions against the base branch.

## Testing

- Not run locally; GitHub Actions workflow will validate the checks on pull requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added automated pull request validation for production Piper Go changes.
  - Pull requests now require a valid, incremented `SubmissionAgent` version when applicable.
  - Checks report clear failures when the version is missing, malformed, or not higher than the base branch.
  - Pull requests without production Go changes complete successfully without requiring a version update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->