### PR TITLE
fix: Use configured root URL in API key examples

### DIFF
--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -27,7 +27,7 @@ func (app *application) routes() http.Handler {
 	// Authenticated Web Routes
 	mux.HandleFunc("/current-track", session.WithAuth(app.spotifyService.HandleCurrentTrack, app.sessionManager))
 	mux.HandleFunc("/history", session.WithAuth(app.spotifyService.HandleTrackHistory, app.sessionManager))
-	mux.HandleFunc("/api-keys", session.WithAuth(app.apiKeyService.HandleAPIKeyManagement(app.database, app.pages), app.sessionManager))
+	mux.HandleFunc("/api-keys", session.WithAuth(app.apiKeyService.HandleAPIKeyManagement(app.database, app.pages, viper.GetString("server.root_url")), app.sessionManager))
 	mux.HandleFunc("/unlink-spotify", session.WithAuth(handleUnlinkSpotify(app.database, app.spotifyService), app.sessionManager))
 	mux.HandleFunc("/login/spotify", session.WithAuth(app.oauthManager.HandleLogin("spotify"), app.sessionManager))
 	mux.HandleFunc("/callback/spotify", session.WithAuth(app.oauthManager.HandleCallback("spotify"), app.sessionManager))

--- a/models/constants.go
+++ b/models/constants.go
@@ -1,3 +1,3 @@
 package models
 
-const SubmissionAgent = "piper/v0.0.13"
+const SubmissionAgent = "piper/v0.0.14"

--- a/pages/templates/apiKeys.gohtml
+++ b/pages/templates/apiKeys.gohtml
@@ -92,7 +92,7 @@
     Or include it as a query parameter (less secure for the key itself):
   </p>
   <pre
-    class="font-mono text-sm p-3 rounded-lg overflow-x-auto bg-white/60 dark:bg-neutral-900/60 border border-neutral-400/20">https://your-piper-instance.com/endpoint?api_key=YOUR_API_KEY</pre>
+    class="font-mono text-sm p-3 rounded-lg overflow-x-auto bg-white/60 dark:bg-neutral-900/60 border border-neutral-400/20">{{ .RootURL }}/endpoint?api_key=YOUR_API_KEY</pre>
 </div>
 
 <script>

--- a/pages/templates_test.go
+++ b/pages/templates_test.go
@@ -15,6 +15,7 @@ func TestPagesRenderIndependently(t *testing.T) {
 	type apiKeysParams struct {
 		Keys     []struct{}
 		NewKeyID string
+		RootURL  string
 		NavBar   NavBar
 	}
 	type lastFMParams struct {

--- a/service/apikey/apikey.go
+++ b/service/apikey/apikey.go
@@ -41,7 +41,7 @@ func jsonError(w http.ResponseWriter, message string, statusCode int) {
 	jsonResponse(w, statusCode, map[string]string{"error": message})
 }
 
-func (s *Service) HandleAPIKeyManagement(database *db.DB, pg *pages.Pages) http.HandlerFunc {
+func (s *Service) HandleAPIKeyManagement(database *db.DB, pg *pages.Pages, rootURL string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 
 		userID, ok := session.GetUserID(r.Context())
@@ -203,10 +203,12 @@ func (s *Service) HandleAPIKeyManagement(database *db.DB, pg *pages.Pages) http.
 		data := struct {
 			Keys     []*dbapikey.ApiKey // Assuming GetUserApiKeys returns this type
 			NewKeyID string             // Changed from NewKey for clarity as it's an ID
+			RootURL  string
 			NavBar   pages.NavBar
 		}{
 			Keys:     keys,
 			NewKeyID: newKeyValueToShow,
+			RootURL:  rootURL,
 			NavBar:   pages.NewNavBar(user, ok).WithBreadcrumb("API keys"),
 		}
 


### PR DESCRIPTION
## Summary

- Pass the configured server root URL to the API key page.
- Render the real root URL in query-parameter examples.
- Update template test data for the new field.

## Testing

- Not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - API key usage examples now display the configured instance URL instead of a generic placeholder.
  - Generated examples accurately reflect the current server address, making them ready to copy and use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->